### PR TITLE
DateFormatter: widen typehint to DateTimeInterface

### DIFF
--- a/src/View/Helper/DateFormat.php
+++ b/src/View/Helper/DateFormat.php
@@ -9,6 +9,7 @@
 namespace Laminas\I18n\View\Helper;
 
 use DateTimeInterface;
+use IntlCalendar;
 use IntlDateFormatter;
 use Laminas\I18n\Exception;
 use Laminas\View\Helper\AbstractHelper;
@@ -56,11 +57,11 @@ class DateFormat extends AbstractHelper
     /**
      * Format a date
      *
-     * @param  DateTimeInterface|int|array $date
-     * @param  int                         $dateType
-     * @param  int                         $timeType
-     * @param  string|null                 $locale
-     * @param  string|null                 $pattern
+     * @param  DateTimeInterface|IntlCalendar|int|array $date
+     * @param  int                                      $dateType
+     * @param  int                                      $timeType
+     * @param  string|null                              $locale
+     * @param  string|null                              $pattern
      * @return string
      */
     public function __invoke(

--- a/src/View/Helper/DateFormat.php
+++ b/src/View/Helper/DateFormat.php
@@ -8,7 +8,7 @@
 
 namespace Laminas\I18n\View\Helper;
 
-use DateTime;
+use DateTimeInterface;
 use IntlDateFormatter;
 use Laminas\I18n\Exception;
 use Laminas\View\Helper\AbstractHelper;
@@ -56,11 +56,11 @@ class DateFormat extends AbstractHelper
     /**
      * Format a date
      *
-     * @param  DateTime|int|array $date
-     * @param  int                $dateType
-     * @param  int                $timeType
-     * @param  string|null        $locale
-     * @param  string|null        $pattern
+     * @param  DateTimeInterface|int|array $date
+     * @param  int                         $dateType
+     * @param  int                         $timeType
+     * @param  string|null                 $locale
+     * @param  string|null                 $pattern
      * @return string
      */
     public function __invoke(

--- a/src/View/HelperTrait.php
+++ b/src/View/HelperTrait.php
@@ -26,7 +26,7 @@ use IntlDateFormatter;
  * @example @var \Laminas\View\Renderer\PhpRenderer|\Laminas\I18n\View\HelperTrait $this
  *
  * @method string currencyFormat(float $number, string|null $currencyCode = null, bool|null $showDecimals = null, string|null $locale = null, string|null $pattern = null)
- * @method string dateFormat(\DateTimeInterface|int|array $date, int $dateType = IntlDateFormatter::NONE, int $timeType = IntlDateFormatter::NONE, string|null $locale = null, string|null $pattern = null)
+ * @method string dateFormat(\DateTimeInterface|\IntlCalendar|int|array $date, int $dateType = IntlDateFormatter::NONE, int $timeType = IntlDateFormatter::NONE, string|null $locale = null, string|null $pattern = null)
  * @method string numberFormat(int|float $number, int|null $formatStyle = null, int|null $formatType = null, string|null $locale = null, int|null $decimals = null, array|null $textAttributes = null)
  * @method string plural(array|string $strings, int $number)
  * @method string translate(string $message, string|null $textDomain = null, string|null $locale = null)

--- a/src/View/HelperTrait.php
+++ b/src/View/HelperTrait.php
@@ -26,7 +26,7 @@ use IntlDateFormatter;
  * @example @var \Laminas\View\Renderer\PhpRenderer|\Laminas\I18n\View\HelperTrait $this
  *
  * @method string currencyFormat(float $number, string|null $currencyCode = null, bool|null $showDecimals = null, string|null $locale = null, string|null $pattern = null)
- * @method string dateFormat(\DateTime|int|array $date, int $dateType = IntlDateFormatter::NONE, int $timeType = IntlDateFormatter::NONE, string|null $locale = null, string|null $pattern = null)
+ * @method string dateFormat(\DateTimeInterface|int|array $date, int $dateType = IntlDateFormatter::NONE, int $timeType = IntlDateFormatter::NONE, string|null $locale = null, string|null $pattern = null)
  * @method string numberFormat(int|float $number, int|null $formatStyle = null, int|null $formatType = null, string|null $locale = null, int|null $decimals = null, array|null $textAttributes = null)
  * @method string plural(array|string $strings, int $number)
  * @method string translate(string $message, string|null $textDomain = null, string|null $locale = null)

--- a/test/View/Helper/DateFormatTest.php
+++ b/test/View/Helper/DateFormatTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\I18n\View\Helper;
 
 use DateTime;
 use IntlDateFormatter;
+use IntlGregorianCalendar;
 use Laminas\I18n\View\Helper\DateFormat as DateFormatHelper;
 use Locale;
 use PHPUnit\Framework\TestCase;
@@ -299,5 +300,14 @@ class DateFormatTest extends TestCase
         $date = new DateTime('2018-01-01');
 
         self::assertSame('Jan 1, 2018', $helper($date, IntlDateFormatter::MEDIUM));
+    }
+
+    public function testIntlCalendarIsHandledAsWell()
+    {
+        $calendar = new IntlGregorianCalendar(2013, 6, 1);
+
+        $helper = new DateFormatHelper();
+        $helper->setTimezone('Europe/Berlin');
+        $this->assertEquals('01-07-2013', $helper->__invoke($calendar, null, null, 'it_IT', 'dd-MM-Y'));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

See official doc: https://www.php.net/manual/en/intldateformatter.format.php#refsect1-intldateformatter.format-parameters