### PR TITLE
PSR-16 standard compliance; closes #49

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
         "php": "^7.3 || ~8.0.0",
         "ext-intl": "*",
         "laminas/laminas-stdlib": "^2.7 || ^3.0",
-        "laminas/laminas-zendframework-bridge": "^1.0",
-        "psr/simple-cache": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-cache": "^2.8.0",

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,11 @@
         "php": "^7.3 || ~8.0.0",
         "ext-intl": "*",
         "laminas/laminas-stdlib": "^2.7 || ^3.0",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.0",
+        "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-cache": "^2.6.1",
+        "laminas/laminas-cache": "^2.8.0",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-config": "^2.6",
         "laminas/laminas-eventmanager": "^2.6.2 || ^3.0",

--- a/docs/book/translator/caching.md
+++ b/docs/book/translator/caching.md
@@ -4,25 +4,17 @@ In production, it makes sense to cache your translations. This not only saves
 you from loading and parsing the individual formats each time, but also
 guarantees an optimized loading procedure.
 
-<!-- markdownlint-disable-next-line MD001 -->
-> ### Installation requirements
->
-> The cache support of laminas-i18n depends on the
-> [laminas-cache](https://docs.laminas.dev/laminas-cache/) component, so be sure
-> to have it installed before getting started:
->
-> ```bash
-> $ composer require laminas/laminas-cache
-> ```
-
 ## Enable Caching
 
-To enable caching, pass a `Laminas\Cache\Storage\Adapter` to the `setCache()`
+To enable caching, pass a `Psr\SimpleCache\CacheInterface` to the `setCache()`
 method.
 
+The following example is based on the use of the
+[laminas-cache](https://docs.laminas.dev/laminas-cache/) component.
+
 ```php
-$translator = new Laminas\I18n\Translator\Translator();
-$cache      = Laminas\Cache\StorageFactory::factory([
+$translator   = new Laminas\I18n\Translator\Translator();
+$cacheStorage = Laminas\Cache\StorageFactory::factory([
     'adapter' => [
         'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
         'options' => [
@@ -30,6 +22,7 @@ $cache      = Laminas\Cache\StorageFactory::factory([
         ],
     ],
 ]);
+$cache        = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator(cacheStorage);
 $translator->setCache($cache);
 ```
 

--- a/docs/book/translator/caching.md
+++ b/docs/book/translator/caching.md
@@ -4,13 +4,21 @@ In production, it makes sense to cache your translations. This not only saves
 you from loading and parsing the individual formats each time, but also
 guarantees an optimized loading procedure.
 
+<!-- markdownlint-disable-next-line MD001 -->
+> ### Installation requirements
+>
+> The cache support of laminas-i18n depends on a PSR-16 compliant cache component,
+> for instance [laminas-cache](https://docs.laminas.dev/laminas-cache/) among others.
+> Be sure to have it installed before getting started:
+>
+> ```bash
+> $ composer require laminas/laminas-cache
+> ```
+
 ## Enable Caching
 
 To enable caching, pass a `Psr\SimpleCache\CacheInterface` to the `setCache()`
 method.
-
-The following example is based on the use of the
-[laminas-cache](https://docs.laminas.dev/laminas-cache/) component.
 
 ```php
 $translator   = new Laminas\I18n\Translator\Translator();
@@ -28,6 +36,10 @@ $translator->setCache($cache);
 
 The explanation of creating a cache and and using different adapters for caching
 can be found in [documentation of laminas-cache](https://docs.laminas.dev/laminas-cache/).
+
+> PSR-16 compliance has been introduced in 2.13.0. Before this version,
+> the `setCache()` mthod expected an instance of `Laminas\Cache\Storage\Adapter` to be passed.
+> This is deprecated and will be removed in 3.0.0.
 
 ## Disable Caching
 

--- a/docs/book/translator/factory.md
+++ b/docs/book/translator/factory.md
@@ -115,8 +115,12 @@ $translator->getPluginManager()->setService(
 
 ### Using a Cache Instance
 
+The following example is based on the use of the
+[laminas-cache](https://docs.laminas.dev/laminas-cache/) component.
+
 ```php
-$cache      = Laminas\Cache\StorageFactory::factory([
+$translator   = new Laminas\I18n\Translator\Translator();
+$cacheStorage = Laminas\Cache\StorageFactory::factory([
     'adapter' => [
         'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
         'options' => [
@@ -124,23 +128,9 @@ $cache      = Laminas\Cache\StorageFactory::factory([
         ],
     ],
 ]);
+$cache        = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator(cacheStorage);
 $translator = Laminas\I18n\Translator\Translator::factory([
     'cache' => $cache,
-]);
-```
-
-### Using Cache Configuration
-
-```php
-$translator = Laminas\I18n\Translator\Translator::factory([
-    'cache' => [
-        'adapter' => [
-        'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
-            'options' => [
-                'cache_dir' => __DIR__ . '/cache',
-            ],
-        ],
-    ],
 ]);
 ```
 

--- a/docs/book/translator/factory.md
+++ b/docs/book/translator/factory.md
@@ -134,6 +134,27 @@ $translator = Laminas\I18n\Translator\Translator::factory([
 ]);
 ```
 
+> PSR-16 compliance has been introduced in 2.13.0. Before this version,
+> the `cache` option expected an instance of `Laminas\Cache\Storage\Adapter` to be passed.
+> This is deprecated and will be removed in 3.0.0.
+
+### Using Cache Configuration
+
+> Using cache configuration is deprecated and will be removed in 3.0.0.
+
+```php
+$translator = Laminas\I18n\Translator\Translator::factory([
+    'cache' => [
+        'adapter' => [
+        'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
+            'options' => [
+                'cache_dir' => __DIR__ . '/cache',
+            ],
+        ],
+    ],
+]);
+```
+
 ## Enable EventManager
 
 ```php


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | yes
| QA            | yes

### Description

Add PSR-16 standard compliance, to be able to use standardized cache component.
