### PR TITLE
Add laminas/laminas-servicemanager to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "require": {
         "php": "^7.3 || ~8.0.0",
         "ext-intl": "*",
+        "laminas/laminas-servicemanager": "^3.2.1",
         "laminas/laminas-stdlib": "^2.7 || ^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
@@ -36,7 +37,6 @@
         "laminas/laminas-config": "^2.6",
         "laminas/laminas-eventmanager": "^2.6.2 || ^3.0",
         "laminas/laminas-filter": "^2.6.1",
-        "laminas/laminas-servicemanager": "^3.2.1",
         "laminas/laminas-validator": "^2.6",
         "laminas/laminas-view": "^2.6.3",
         "phpunit/phpunit": "^9.3"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
Unless I am wrong, however the `Laminas\I18n\Translator` is used, all paths are leading to usage of the `LoaderPluginManager` which extends the `Laminas\ServiceManager\AbstractPluginManager` class, and thus, require the `laminas/laminas-servicemanager` package to be installed.

Moving the dependency from `require-dev` to `require` will permit to use the `laminas/laminas-i18n` package without having to manually add `laminas/laminas-servicemanager` to the project requirements.