### PR TITLE
Simplify redirects of legacy docs

### DIFF
--- a/docs/book/filters.md
+++ b/docs/book/filters.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-i18n/filters/introduction/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-i18n/filters/introduction/';
-  });
-</script>

--- a/docs/book/validators.md
+++ b/docs/book/validators.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-i18n/validators/introduction/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-i18n/validators/introduction/';
-  });
-</script>

--- a/docs/book/view-helpers.md
+++ b/docs/book/view-helpers.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-i18n/view-helpers/introduction/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-i18n/view-helpers/introduction/';
-  });
-</script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,10 +38,6 @@ nav:
         - 'Stand-Alone': application-integration/stand-alone.md
     - Migration:
         - 'Migration from Versions prior to 2.4': migration/migration-to-v2.4.md
-    - '_hidden-legacy-page-links':
-        - '_filters': filters.md
-        - '_validators': validators.md
-        - '_view-helpers': view-helpers.md
 site_name: laminas-i18n
 site_description: 'Provide translations for your application, and filter and validate internationalized values.'
 repo_url: 'https://github.com/laminas/laminas-i18n'
@@ -54,3 +50,10 @@ extra:
         headline: Related Components
         links:
             - 'Translation Resources': https://docs.laminas.dev/laminas-i18n-resources/
+plugins:
+    - search
+    - redirects:
+          redirect_maps:
+              filters.md: filters/introduction.md
+              validators.md: validators/introduction.md
+              view-helpers.md: view-helpers/introduction.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The docs folder contains several manual redirects, i.d. HTML documents with a hard-coded redirect for legacy URLs. With the [adoption of the MkDocs redirect plugin](https://github.com/laminas/documentation-theme/pull/65) there is a simpler solution available.

This PR moves the redirects for legacy URLs in `mkdocs.yml` and removes the manually created HTML documents from Git.