### PR TITLE
Marks PostCode::setService() and PostCode::getService() as deprecated

### DIFF
--- a/src/Validator/PostCode.php
+++ b/src/Validator/PostCode.php
@@ -302,6 +302,9 @@ class PostCode extends AbstractValidator
     /**
      * Returns the actual set service
      *
+     * @deprecated since 2.12.0, this method will be removed in version 3.0.0 of this component.
+     *             Additional validations should be done via a validation chain.
+     *
      * @return mixed|null
      */
     public function getService()
@@ -311,6 +314,9 @@ class PostCode extends AbstractValidator
 
     /**
      * Sets a new callback for service validation
+     *
+     * @deprecated since 2.12.0, this method will be removed in version 3.0.0 of this component.
+     *             Additional validations should be done via a validation chain.
      *
      * @param mixed|null $service
      * @return $this


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Feature Removal | yes

Fixes #6