### PR TITLE
Laminas\I18n\View\Helper\AbstractTranslatorHelper now extends Laminas…

### DIFF
--- a/src/View/Helper/AbstractTranslatorHelper.php
+++ b/src/View/Helper/AbstractTranslatorHelper.php
@@ -4,9 +4,9 @@ namespace Laminas\I18n\View\Helper;
 
 use Laminas\I18n\Translator\TranslatorAwareInterface;
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
-use Laminas\View\Helper\AbstractHelper;
+use Laminas\View\Helper\AbstractHtmlElement;
 
-abstract class AbstractTranslatorHelper extends AbstractHelper implements
+abstract class AbstractTranslatorHelper extends AbstractHtmlElement implements
     TranslatorAwareInterface
 {
     /**


### PR DESCRIPTION
…\View\Helper\AbstractHtmlElement, rather than Laminas\View\Helper\AbstractHelper

This gives e.g. Laminas\Form\View\Helper\AbstractHelper more features, such as normalizeId()



|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| New Feature   | yes

### Description
It would be neat, if Laminas\I18n\View\Helper\AbstractTranslatorHelper extends Laminas\View\Helper\AbstractHtmlElement, rather than Laminas\View\Helper\AbstractHelper.

Why?
Laminas\Form\View\Helper\AbstractHelper extends Laminas\I18n\View\Helper\AbstractTranslatorHelper (as BaseAbstractHelper). Let's say you want to create your own Form-View-Helper. Any form element will naturally be a HTML-Element (like <input>). As soon as you use HTML-Elements, the added methods of Laminas\View\Helper\AbstractHtmlElement would come in handy, esp. the method 'normalizeId($value)', for instance if my custom Form-Element-Helper needs to normalize an element name which has a name like 'foo-element[bar]'. Thank You.
