### PR TITLE
Disconnect view helper inheritance hierarchy

### DIFF
--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\View\Helper;
+
+use Laminas\View\Helper\HelperInterface;
+use Laminas\View\Renderer\RendererInterface;
+
+/**
+ * @deprecated since >= 2.15 If it is necessary to access the renderer from within the plugin, you should inject it
+ *             as a constructor dependency
+ * @internal
+ * @psalm-internal \Laminas\I18n\View
+ * @psalm-suppress DeprecatedProperty
+ */
+abstract class AbstractHelper implements HelperInterface
+{
+    /**
+     * View object instance
+     *
+     * @deprecated since >= 2.15 If it is necessary to access the renderer from within the plugin, you should inject it
+     *             as a constructor dependency
+     *
+     * @var RendererInterface|null
+     */
+    protected $view;
+
+    /**
+     * Set the View object
+     *
+     * @deprecated since >= 2.15 If it is necessary to access the renderer from within the plugin, you should inject it
+     *             as a constructor dependency
+     *
+     * @return $this
+     */
+    public function setView(RendererInterface $view)
+    {
+        $this->view = $view;
+        return $this;
+    }
+
+    /**
+     * Get the view object
+     *
+     * @deprecated since >= 2.15 If it is necessary to access the renderer from within the plugin, you should inject it
+     *             as a constructor dependency
+     *
+     * @psalm-suppress ImplementedReturnTypeMismatch
+     * @return RendererInterface|null
+     */
+    public function getView()
+    {
+        return $this->view;
+    }
+}

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -8,9 +8,10 @@ use Laminas\View\Helper\HelperInterface;
 use Laminas\View\Renderer\RendererInterface;
 
 /**
+ * @internal
  * @deprecated since >= 2.15 If it is necessary to access the renderer from within the plugin, you should inject it
  *             as a constructor dependency
- * @internal
+ *
  * @psalm-internal \Laminas\I18n\View
  * @psalm-suppress DeprecatedProperty
  */

--- a/src/View/Helper/AbstractTranslatorHelper.php
+++ b/src/View/Helper/AbstractTranslatorHelper.php
@@ -4,8 +4,8 @@ namespace Laminas\I18n\View\Helper;
 
 use Laminas\I18n\Translator\TranslatorAwareInterface;
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
-use Laminas\View\Helper\AbstractHelper;
 
+/** @psalm-suppress DeprecatedClass */
 abstract class AbstractTranslatorHelper extends AbstractHelper implements
     TranslatorAwareInterface
 {

--- a/src/View/Helper/CurrencyFormat.php
+++ b/src/View/Helper/CurrencyFormat.php
@@ -12,6 +12,7 @@ use function sprintf;
 
 /**
  * View helper for formatting currency.
+ *
  * @psalm-suppress DeprecatedClass
  */
 class CurrencyFormat extends AbstractHelper

--- a/src/View/Helper/CurrencyFormat.php
+++ b/src/View/Helper/CurrencyFormat.php
@@ -2,7 +2,6 @@
 
 namespace Laminas\I18n\View\Helper;
 
-use Laminas\View\Helper\AbstractHelper;
 use Locale;
 use NumberFormatter;
 
@@ -13,6 +12,7 @@ use function sprintf;
 
 /**
  * View helper for formatting currency.
+ * @psalm-suppress DeprecatedClass
  */
 class CurrencyFormat extends AbstractHelper
 {

--- a/src/View/Helper/DateFormat.php
+++ b/src/View/Helper/DateFormat.php
@@ -5,7 +5,6 @@ namespace Laminas\I18n\View\Helper;
 use DateTimeInterface;
 use IntlCalendar;
 use IntlDateFormatter;
-use Laminas\View\Helper\AbstractHelper;
 use Locale;
 
 use function date_default_timezone_get;
@@ -13,6 +12,7 @@ use function md5;
 
 /**
  * View helper for formatting dates.
+ * @psalm-suppress DeprecatedClass
  */
 class DateFormat extends AbstractHelper
 {

--- a/src/View/Helper/DateFormat.php
+++ b/src/View/Helper/DateFormat.php
@@ -12,6 +12,7 @@ use function md5;
 
 /**
  * View helper for formatting dates.
+ *
  * @psalm-suppress DeprecatedClass
  */
 class DateFormat extends AbstractHelper

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -2,7 +2,6 @@
 
 namespace Laminas\I18n\View\Helper;
 
-use Laminas\View\Helper\AbstractHelper;
 use Locale;
 use NumberFormatter;
 
@@ -13,6 +12,7 @@ use function serialize;
 
 /**
  * View helper for formatting dates.
+ * @psalm-suppress DeprecatedClass
  */
 class NumberFormat extends AbstractHelper
 {

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -12,6 +12,7 @@ use function serialize;
 
 /**
  * View helper for formatting dates.
+ *
  * @psalm-suppress DeprecatedClass
  */
 class NumberFormat extends AbstractHelper

--- a/src/View/Helper/Plural.php
+++ b/src/View/Helper/Plural.php
@@ -19,6 +19,7 @@ use function sprintf;
  * However, you can find most of the up-to-date plural rules for most languages in those links:
  *      - http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
  *      - https://developer.mozilla.org/en-US/docs/Localization_and_Plurals
+ *
  * @psalm-suppress DeprecatedClass
  */
 class Plural extends AbstractHelper

--- a/src/View/Helper/Plural.php
+++ b/src/View/Helper/Plural.php
@@ -4,7 +4,6 @@ namespace Laminas\I18n\View\Helper;
 
 use Laminas\I18n\Exception;
 use Laminas\I18n\Translator\Plural\Rule as PluralRule;
-use Laminas\View\Helper\AbstractHelper;
 
 use function is_array;
 use function sprintf;
@@ -20,6 +19,7 @@ use function sprintf;
  * However, you can find most of the up-to-date plural rules for most languages in those links:
  *      - http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
  *      - https://developer.mozilla.org/en-US/docs/Localization_and_Plurals
+ * @psalm-suppress DeprecatedClass
  */
 class Plural extends AbstractHelper
 {

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\I18n\View\Helper;
+
+use Laminas\I18n\View\Helper\AbstractHelper;
+use Laminas\I18n\View\Helper\Plural as PluralHelper;
+use Laminas\View\Renderer\RendererInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-suppress DeprecatedClass, DeprecatedMethod, InternalMethod
+ */
+class AbstractHelperTest extends TestCase
+{
+    private PluralHelper $helper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->helper = new PluralHelper();
+    }
+
+    public function testHelperHasAbstractHelperInItsHierarchy(): void
+    {
+        /** @psalm-suppress RedundantCondition */
+        self::assertTrue($this->helper instanceof AbstractHelper);
+    }
+
+    public function testThatTheViewIsInitiallyNull(): void
+    {
+        self::assertNull($this->helper->getView());
+    }
+
+    public function testThatTheViewCanBeSet(): void
+    {
+        $renderer = $this->createMock(RendererInterface::class);
+        $this->helper->setView($renderer);
+        self::assertSame($renderer, $this->helper->getView());
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes and no…
| QA            | yes

### Description

This pull re-implements `AbstractHelper` with `getView` and `setView` and deprecates it at the same time, marking it as internal.

Whilst behaviour is preserved, consumers should be testing for the `HelperInterface` but they are probably testing for `AbstractHelper` in the View namespace, therefore this is probably a BC Break.

An alternative approach would be to first upgrade to view `2.20.0` which isn't released yet. 2.20 comes with [a trait that deprecates `getView` and `setView`](https://github.com/gsteel/laminas-view/blob/2.20.x/src/Helper/DeprecatedAbstractHelperHierarchyTrait.php).


