### PR TITLE
Exclude dev files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,11 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
+/.laminas-ci.json export-ignore
 /docs/ export-ignore
 /mkdocs.yml export-ignore
 /phpcs.xml export-ignore
 /phpunit.xml.dist export-ignore
+/psalm.xml export-ignore
+/psalm-baseline.xml export-ignore
 /test/ export-ignore


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
These files are not usefull in dist package, so I guess they could be removed.