### PR TITLE
Country Code Data List: Improve docs, add view helper alias to IDE autocompletion trait

### DIFF
--- a/docs/book/view-helpers/country-code-data-list.md
+++ b/docs/book/view-helpers/country-code-data-list.md
@@ -33,7 +33,7 @@ echo $this->countryCodeDataList('de_DE'); // or just 'DE'
 Outputs:
 
 ```html
-<datalist >
+<datalist>
     <option value="AD" label="Andorra">
     <option value="AE" label="Vereinigte&#x20;Arabische&#x20;Emirate">
     <option value="AF" label="Afghanistan">
@@ -59,6 +59,13 @@ Outputs:
     <option value="AD" label="Andorra">
     <!-- etc… -->
 </datalist>
+```
+
+In order for the html data list to be used with a form input, you must target the list from the input using [the `list` attribute](). For example:
+
+```php
+$formElement = new \Laminas\Form\Element\Text('my-input');
+$formElement->setAttribute('list', 'country-codes');
 ```
 
 ## Restricting the List of Available Countries

--- a/docs/book/view-helpers/country-code-data-list.md
+++ b/docs/book/view-helpers/country-code-data-list.md
@@ -61,7 +61,7 @@ Outputs:
 </datalist>
 ```
 
-In order for the html data list to be used with a form input, you must target the list from the input using [the `list` attribute](). For example:
+In order for the html data list to be used with a form input, you must target the list from the input using [the `list` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#list). For example:
 
 ```php
 $formElement = new \Laminas\Form\Element\Text('my-input');

--- a/docs/book/view-helpers/country-code-data-list.md
+++ b/docs/book/view-helpers/country-code-data-list.md
@@ -61,12 +61,12 @@ Outputs:
 </datalist>
 ```
 
-In order for the html data list to be used with a form input, you must target the list from the input using [the `list` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#list). For example:
+In order for the html data list to be used with a form input, you must target the list from the input using [the `list` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#list).
+For example:
 
 ```php
-$formElement = new \Laminas\Form\Element\Text('my-input');
+$formElement = new Laminas\Form\Element\Text('country');
 $formElement->setAttribute('list', 'country-codes');
-```
 
 ## Restricting the List of Available Countries
 

--- a/src/View/HelperTrait.php
+++ b/src/View/HelperTrait.php
@@ -19,6 +19,7 @@ use IntlDateFormatter;
  *
  * @example @var \Laminas\View\Renderer\PhpRenderer|\Laminas\I18n\View\HelperTrait $this
  *
+ * @method string countryCodeDataList(?string $locale = null, array $dataListAttributes = [])
  * @method string currencyFormat(float $number, string|null $currencyCode = null, bool|null $showDecimals = null, string|null $locale = null, string|null $pattern = null)
  * @method string dateFormat(\DateTimeInterface|\IntlCalendar|int|array $date, int $dateType = IntlDateFormatter::NONE, int $timeType = IntlDateFormatter::NONE, string|null $locale = null, string|null $pattern = null)
  * @method string numberFormat(int|float $number, int|null $formatStyle = null, int|null $formatType = null, string|null $locale = null, int|null $decimals = null, array|null $textAttributes = null)


### PR DESCRIPTION
### Description

A couple of minor improvements to #86 

- Updates docs with a note about how to reference a rendered `datalist` from a form input.
- Adds the view helper alias for `countryCodeDataList` to the shipped IDE autocompletion trait
