### PR TITLE
Fixed: handling non-scalars in NumberParse filter

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -55,9 +55,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Filter/NumberParse.php">
-    <MixedArgument>
-      <code>$value</code>
-    </MixedArgument>
     <RedundantCastGivenDocblockType>
       <code>(int) $style</code>
       <code>(int) $type</code>
@@ -773,6 +770,7 @@
   <file src="test/Filter/NumberParseTest.php">
     <PossiblyUnusedMethod>
       <code>formattedToNumberProvider</code>
+      <code>formatNonNumberProvider</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/TestAsset/ModuleEventInterface.php">

--- a/src/Filter/NumberParse.php
+++ b/src/Filter/NumberParse.php
@@ -9,8 +9,10 @@ use Traversable;
 
 use function intl_get_error_message;
 use function is_array;
+use function is_bool;
 use function is_float;
 use function is_int;
+use function is_scalar;
 use function iterator_to_array;
 
 /**
@@ -149,6 +151,10 @@ class NumberParse extends AbstractLocale
      */
     public function filter($value)
     {
+        if (! is_scalar($value) || is_bool($value)) {
+            return $value;
+        }
+
         if (
             ! is_int($value)
             && ! is_float($value)

--- a/test/Filter/NumberParseTest.php
+++ b/test/Filter/NumberParseTest.php
@@ -8,6 +8,7 @@ use Laminas\I18n\Filter\NumberParse as NumberParseFilter;
 use LaminasTest\I18n\TestCase;
 use NumberFormatter;
 use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
 
 class NumberParseTest extends TestCase
 {
@@ -64,6 +65,38 @@ class NumberParseTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 '1 234 567,891',
                 1234567.891,
+            ],
+        ];
+    }
+
+    #[DataProvider('formatNonNumberProvider')]
+    public function testFormattedWithNonNumbers(
+        mixed $value,
+        mixed $expected
+    ): void {
+        $filter = new NumberParseFilter('en_US', NumberFormatter::DEFAULT_STYLE, NumberFormatter::TYPE_DOUBLE);
+        self::assertEquals($expected, $filter->filter($value));
+    }
+
+    /** @return array<array-key, array{0: mixed, 1: mixed}> */
+    public static function formatNonNumberProvider(): array
+    {
+        return [
+            [
+                null,
+                null,
+            ],
+            [
+                [],
+                [],
+            ],
+            [
+                new stdClass(),
+                new stdClass(),
+            ],
+            [
+                false,
+                false,
             ],
         ];
     }


### PR DESCRIPTION
`filter()` now returns `$value` as-is for non-scalar and boolean values, which fixes triggering a deprection warning since PHP 8.1.

Fix for issue #105

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
