### PR TITLE
IsFloat validator should return a standard error message for empty strings

### DIFF
--- a/src/Validator/IsFloat.php
+++ b/src/Validator/IsFloat.php
@@ -118,6 +118,12 @@ class IsFloat extends AbstractValidator
             return true;
         }
 
+        if ($value === '') {
+            $this->error(self::NOT_FLOAT);
+
+            return false;
+        }
+
         // Need to check if this is scientific formatted string. If not, switch to decimal.
         $formatter = new NumberFormatter($this->getLocale(), NumberFormatter::SCIENTIFIC);
 

--- a/test/Validator/IsFloatTest.php
+++ b/test/Validator/IsFloatTest.php
@@ -217,4 +217,14 @@ class IsFloatTest extends TestCase
         $message = $this->validator->getMessages();
         self::assertStringContainsString('does not appear to be a float', $message['notFloat']);
     }
+
+    public function testEmptyStringShouldReturnStandardErrorMessage(): void
+    {
+        self::assertFalse($this->validator->isValid(''));
+        $message = $this->validator->getMessages();
+        self::assertStringContainsString(
+            'does not appear to be a float',
+            $message['notFloat']
+        );
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The following code throws an `AssertionError`:

```php
$validator = new Laminas\I18n\Validator\IsFloat();
var_dump($validator->isValid(''));
```

```
Fatal error: Uncaught AssertionError: assert($lastStringGroup !== '') in /src/Validator/IsFloat.php:242
```

https://github.com/laminas/laminas-i18n/blob/4f23433e415b14c4d66a7d7d1983c5890ac9ed2a/src/Validator/IsFloat.php#L233-L242

These lines were introduced with #104: https://github.com/laminas/laminas-i18n/pull/104/commits/5062ef1b6e725eb2a05c56759ac241c1ef776cf2

In previous versions this was not a problem:

```php
$validator = new Laminas\I18n\Validator\IsFloat();
var_dump($validator->isValid('')); // false
var_dump($validator->getMessages()); ['notFloat' => 'The input does not appear to be a float']
```