### PR TITLE
Add the possibility to set the minimum number of decimals in the numb…

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -34,6 +34,11 @@
                 <directory name="test" />
             </errorLevel>
         </DeprecatedMethod>
+        <PossiblyUnusedMethod>
+            <errorLevel type="suppress">
+                <directory name="test" />
+            </errorLevel>
+        </PossiblyUnusedMethod>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -60,8 +60,6 @@ class NumberFormat extends AbstractHelper
      * Format a number
      *
      * @param  int|float   $number
-     *
-     * @return string
      */
     public function __invoke(
         $number,
@@ -71,7 +69,7 @@ class NumberFormat extends AbstractHelper
         ?int $maxDecimals = null,
         ?array $textAttributes = null,
         ?int $minDecimals = null
-    ) {
+    ): string {
         if (null === $locale) {
             $locale = $this->getLocale();
         }
@@ -125,9 +123,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set format style to use instead of the default
-     *
-     * @param  int $formatStyle
-     * @return $this
      */
     public function setFormatStyle(int $formatStyle): self
     {
@@ -137,8 +132,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Get the format style to use
-     *
-     * @return int
      */
     public function getFormatStyle(): int
     {
@@ -151,9 +144,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set format type to use instead of the default
-     *
-     * @param  int $formatType
-     * @return $this
      */
     public function setFormatType($formatType): self
     {
@@ -163,8 +153,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Get the format type to use
-     *
-     * @return int
      */
     public function getFormatType(): int
     {
@@ -176,9 +164,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set number (both min & max) of decimals to use instead of the default.
-     *
-     * @param  int|null $decimals
-     * @return $this
      */
     public function setDecimals(?int $decimals): self
     {
@@ -189,9 +174,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set the maximum number of decimals to use instead of the default.
-     *
-     * @param  int|null $maxDecimals
-     * @return $this
      */
     public function setMaxDecimals(?int $maxDecimals): self
     {
@@ -201,9 +183,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set the minimum number of decimals to use instead of the default.
-     *
-     * @param int|null $minDecimals
-     * @return $this
      */
     public function setMinDecimals(?int $minDecimals): self
     {
@@ -213,8 +192,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Get number of decimals.
-     *
-     * @return int|null
      */
     public function getDecimals(): ?int
     {
@@ -223,8 +200,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Get the maximum number of decimals.
-     *
-     * @return int|null
      */
     public function getMaxDecimals(): ?int
     {
@@ -233,8 +208,6 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Get the minimum number of decimals.
-     *
-     * @return int|null
      */
     public function getMinDecimals(): ?int
     {
@@ -243,20 +216,15 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set locale to use instead of the default.
-     *
-     * @param  string $locale
-     * @return $this
      */
-    public function setLocale($locale): self
+    public function setLocale(?string $locale): self
     {
-        $this->locale = (string) $locale;
+        $this->locale = $locale;
         return $this;
     }
 
     /**
      * Get the locale to use
-     *
-     * @return string
      */
     public function getLocale(): string
     {
@@ -267,18 +235,11 @@ class NumberFormat extends AbstractHelper
         return $this->locale;
     }
 
-    /**
-     * @return array
-     */
     public function getTextAttributes(): array
     {
         return $this->textAttributes;
     }
 
-    /**
-     * @param array $textAttributes
-     * @return $this
-     */
     public function setTextAttributes(array $textAttributes): self
     {
         $this->textAttributes = $textAttributes;

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -21,29 +21,21 @@ class NumberFormat extends AbstractHelper
 
     /**
      * The maximum number of decimals to use.
-     *
-     * @var int
      */
     protected ?int $maxDecimals = null;
 
     /**
      * The minimum number of decimals to use.
-     *
-     * @var int
      */
     protected ?int $minDecimals = null;
 
     /**
      * NumberFormat style to use
-     *
-     * @var int
      */
     protected ?int $formatStyle = null;
 
     /**
      * NumberFormat type to use
-     *
-     * @var int
      */
     protected ?int $formatType = null;
 
@@ -56,15 +48,11 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Text attributes.
-     *
-     * @var array
      */
     protected array $textAttributes = [];
 
     /**
      * Locale to use instead of the default
-     *
-     * @var string
      */
     protected ?string $locale = null;
 
@@ -72,12 +60,6 @@ class NumberFormat extends AbstractHelper
      * Format a number
      *
      * @param  int|float   $number
-     * @param  int|null    $formatStyle
-     * @param  int|null    $formatType
-     * @param  string|null $locale
-     * @param  int|null    $maxDecimals
-     * @param  array|null  $textAttributes
-     * @param  int|null     $minDecimals
      *
      * @return string
      */
@@ -114,7 +96,7 @@ class NumberFormat extends AbstractHelper
         }
 
         $formatterId = md5(
-            $formatStyle . "\0" . $locale . "\0" . $minDecimals . "\0" . $maxDecimals . "\0"
+            $formatStyle . "\0" . $locale . "\0" . ($minDecimals ?? '') . "\0" . ($maxDecimals ?? '') . "\0"
             . md5(serialize($textAttributes))
         );
 
@@ -195,13 +177,13 @@ class NumberFormat extends AbstractHelper
     /**
      * Set number (both min & max) of decimals to use instead of the default.
      *
-     * @param  int $decimals
+     * @param  int|null $decimals
      * @return $this
      */
-    public function setDecimals($decimals): self
+    public function setDecimals(?int $decimals): self
     {
-        $this->minDecimals = (int) $decimals;
-        $this->maxDecimals = (int) $decimals;
+        $this->minDecimals = $decimals;
+        $this->maxDecimals = $decimals;
         return $this;
     }
 

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -144,9 +144,9 @@ class NumberFormat extends AbstractHelper
      * @param  int $formatStyle
      * @return $this
      */
-    public function setFormatStyle($formatStyle): self
+    public function setFormatStyle(int $formatStyle): self
     {
-        $this->formatStyle = (int) $formatStyle;
+        $this->formatStyle = $formatStyle;
         return $this;
     }
 
@@ -229,9 +229,9 @@ class NumberFormat extends AbstractHelper
     /**
      * Get number of decimals.
      *
-     * @return int
+     * @return int|null
      */
-    public function getDecimals(): int
+    public function getDecimals(): ?int
     {
         return $this->maxDecimals;
     }
@@ -239,9 +239,9 @@ class NumberFormat extends AbstractHelper
     /**
      * Get the maximum number of decimals.
      *
-     * @return int
+     * @return int|null
      */
-    public function getMaxDecimals(): int
+    public function getMaxDecimals(): ?int
     {
         return $this->maxDecimals;
     }
@@ -249,9 +249,9 @@ class NumberFormat extends AbstractHelper
     /**
      * Get the minimum number of decimals.
      *
-     * @return int
+     * @return int|null
      */
-    public function getMinDecimals(): int
+    public function getMinDecimals(): ?int
     {
         return $this->minDecimals;
     }

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Laminas\I18n\View\Helper;
 
 use Laminas\View\Helper\AbstractHelper;
@@ -23,58 +21,75 @@ class NumberFormat extends AbstractHelper
 
     /**
      * The maximum number of decimals to use.
+     *
+     * @var int
      */
-    protected ?int $maxDecimals = null;
+    protected $maxDecimals;
 
     /**
      * The minimum number of decimals to use.
+     *
+     * @var int
      */
-    protected ?int $minDecimals = null;
+    protected $minDecimals;
 
     /**
      * NumberFormat style to use
+     *
+     * @var int
      */
-    protected ?int $formatStyle = null;
+    protected $formatStyle;
 
     /**
      * NumberFormat type to use
+     *
+     * @var int
      */
-    protected ?int $formatType = null;
+    protected $formatType;
 
     /**
      * Formatter instances
      *
      * @var array<string, NumberFormatter>
      */
-    protected array $formatters = [];
+    protected $formatters = [];
 
     /**
      * Text attributes.
      *
      * @var array<int, string>
      */
-    protected array $textAttributes = [];
+    protected $textAttributes = [];
 
     /**
      * Locale to use instead of the default
+     *
+     * @var string
      */
-    protected ?string $locale = null;
+    protected $locale;
 
     /**
      * Format a number
      *
-     * @param  int|float           $number
-     * @param  array<int, string>  $textAttributes
+     * @param int|float          $number
+     * @param int|null           $formatStyle
+     * @param int|null           $formatType
+     * @param string|null        $locale
+     * @param int|null           $maxDecimals
+     * @param array<int, string> $textAttributes
+     * @param int|float          $number
+     * @param int|null           $minDecimals
+     * @return string
      */
     public function __invoke(
         $number,
-        ?int $formatStyle = null,
-        ?int $formatType = null,
-        ?string $locale = null,
-        ?int $maxDecimals = null,
+        $formatStyle = null,
+        $formatType = null,
+        $locale = null,
+        $maxDecimals = null,
         ?array $textAttributes = null,
-        ?int $minDecimals = null
-    ): string {
+        $minDecimals = null
+    ) {
         if (null === $locale) {
             $locale = $this->getLocale();
         }
@@ -128,17 +143,22 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set format style to use instead of the default
+     *
+     * @param  int $formatStyle
+     * @return $this
      */
-    public function setFormatStyle(int $formatStyle): self
+    public function setFormatStyle($formatStyle)
     {
-        $this->formatStyle = $formatStyle;
+        $this->formatStyle = (int) $formatStyle;
         return $this;
     }
 
     /**
      * Get the format style to use
+     *
+     * @return int
      */
-    public function getFormatStyle(): int
+    public function getFormatStyle()
     {
         if (null === $this->formatStyle) {
             $this->formatStyle = NumberFormatter::DECIMAL;
@@ -149,17 +169,22 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set format type to use instead of the default
+     *
+     * @param  int $formatType
+     * @return $this
      */
-    public function setFormatType(?int $formatType): self
+    public function setFormatType($formatType)
     {
-        $this->formatType = $formatType;
+        $this->formatType = (int) $formatType;
         return $this;
     }
 
     /**
      * Get the format type to use
+     *
+     * @return int
      */
-    public function getFormatType(): int
+    public function getFormatType()
     {
         if (null === $this->formatType) {
             $this->formatType = NumberFormatter::TYPE_DEFAULT;
@@ -168,9 +193,12 @@ class NumberFormat extends AbstractHelper
     }
 
     /**
-     * Set number (both min & max) of decimals to use instead of the default.
+     * Set number of decimals (both min & max) to use instead of the default.
+     *
+     * @param  int $decimals
+     * @return $this
      */
-    public function setDecimals(?int $decimals): self
+    public function setDecimals($decimals)
     {
         $this->minDecimals = $decimals;
         $this->maxDecimals = $decimals;
@@ -179,8 +207,11 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set the maximum number of decimals to use instead of the default.
+     *
+     * @param int $maxDecimals
+     * @return $this
      */
-    public function setMaxDecimals(?int $maxDecimals): self
+    public function setMaxDecimals($maxDecimals)
     {
         $this->maxDecimals = $maxDecimals;
         return $this;
@@ -188,8 +219,11 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Set the minimum number of decimals to use instead of the default.
+     *
+     * @param int $minDecimals
+     * @return $this
      */
-    public function setMinDecimals(?int $minDecimals): self
+    public function setMinDecimals($minDecimals)
     {
         $this->minDecimals = $minDecimals;
         return $this;
@@ -197,41 +231,52 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Get number of decimals.
+     *
+     * @return int
      */
-    public function getDecimals(): ?int
+    public function getDecimals()
     {
         return $this->maxDecimals;
     }
 
     /**
      * Get the maximum number of decimals.
+     *
+     * @return int
      */
-    public function getMaxDecimals(): ?int
+    public function getMaxDecimals()
     {
         return $this->maxDecimals;
     }
 
     /**
      * Get the minimum number of decimals.
+     *
+     * @return int
      */
-    public function getMinDecimals(): ?int
+    public function getMinDecimals()
     {
         return $this->minDecimals;
     }
 
     /**
      * Set locale to use instead of the default.
+     *
+     * @param  string $locale
+     * @return $this
      */
-    public function setLocale(?string $locale): self
+    public function setLocale($locale)
     {
-        $this->locale = $locale;
+        $this->locale = (string) $locale;
         return $this;
     }
 
     /**
      * Get the locale to use
+     *
+     * @return string
      */
-    public function getLocale(): string
+    public function getLocale()
     {
         if ($this->locale === null) {
             $this->locale = Locale::getDefault();
@@ -243,15 +288,16 @@ class NumberFormat extends AbstractHelper
     /**
      * @return array<int, string>
      */
-    public function getTextAttributes(): array
+    public function getTextAttributes()
     {
         return $this->textAttributes;
     }
 
     /**
      * @param array<int, string> $textAttributes
+     * @return $this
      */
-    public function setTextAttributes(array $textAttributes): self
+    public function setTextAttributes(array $textAttributes)
     {
         $this->textAttributes = $textAttributes;
         return $this;

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -123,8 +123,11 @@ class NumberFormat extends AbstractHelper
         } else {
             $formatter = new NumberFormatter($locale, $formatStyle);
 
-            if ($maxDecimals !== null) {
+            if ($minDecimals !== null) {
                 $formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $minDecimals);
+            }
+
+            if ($maxDecimals !== null) {
                 $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxDecimals);
             }
 

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\I18n\View\Helper;
 
 use Laminas\View\Helper\AbstractHelper;

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -24,49 +24,49 @@ class NumberFormat extends AbstractHelper
      *
      * @var int
      */
-    protected $maxDecimals;
+    protected ?int $maxDecimals = null;
 
     /**
      * The minimum number of decimals to use.
      *
      * @var int
      */
-    protected $minDecimals;
+    protected ?int $minDecimals = null;
 
     /**
      * NumberFormat style to use
      *
      * @var int
      */
-    protected $formatStyle;
+    protected ?int $formatStyle = null;
 
     /**
      * NumberFormat type to use
      *
      * @var int
      */
-    protected $formatType;
+    protected ?int $formatType = null;
 
     /**
      * Formatter instances
      *
      * @var array<string, NumberFormatter>
      */
-    protected $formatters = [];
+    protected array $formatters = [];
 
     /**
      * Text attributes.
      *
      * @var array
      */
-    protected $textAttributes = [];
+    protected array $textAttributes = [];
 
     /**
      * Locale to use instead of the default
      *
      * @var string
      */
-    protected $locale;
+    protected ?string $locale = null;
 
     /**
      * Format a number
@@ -83,10 +83,10 @@ class NumberFormat extends AbstractHelper
      */
     public function __invoke(
         $number,
-        $formatStyle = null,
-        $formatType = null,
-        $locale = null,
-        $maxDecimals = null,
+        ?int $formatStyle = null,
+        ?int $formatType = null,
+        ?string $locale = null,
+        ?int $maxDecimals = null,
         ?array $textAttributes = null,
         ?int $minDecimals = null
     ) {
@@ -144,7 +144,7 @@ class NumberFormat extends AbstractHelper
      * @param  int $formatStyle
      * @return $this
      */
-    public function setFormatStyle($formatStyle)
+    public function setFormatStyle($formatStyle): self
     {
         $this->formatStyle = (int) $formatStyle;
         return $this;
@@ -155,7 +155,7 @@ class NumberFormat extends AbstractHelper
      *
      * @return int
      */
-    public function getFormatStyle()
+    public function getFormatStyle(): int
     {
         if (null === $this->formatStyle) {
             $this->formatStyle = NumberFormatter::DECIMAL;
@@ -170,7 +170,7 @@ class NumberFormat extends AbstractHelper
      * @param  int $formatType
      * @return $this
      */
-    public function setFormatType($formatType)
+    public function setFormatType($formatType): self
     {
         $this->formatType = (int) $formatType;
         return $this;
@@ -181,7 +181,7 @@ class NumberFormat extends AbstractHelper
      *
      * @return int
      */
-    public function getFormatType()
+    public function getFormatType(): int
     {
         if (null === $this->formatType) {
             $this->formatType = NumberFormatter::TYPE_DEFAULT;
@@ -195,10 +195,10 @@ class NumberFormat extends AbstractHelper
      * @param  int $decimals
      * @return $this
      */
-    public function setDecimals($decimals)
+    public function setDecimals($decimals): self
     {
-        $this->minDecimals = $decimals;
-        $this->maxDecimals = $decimals;
+        $this->minDecimals = (int) $decimals;
+        $this->maxDecimals = (int) $decimals;
         return $this;
     }
 
@@ -231,7 +231,7 @@ class NumberFormat extends AbstractHelper
      *
      * @return int
      */
-    public function getDecimals()
+    public function getDecimals(): int
     {
         return $this->maxDecimals;
     }
@@ -262,7 +262,7 @@ class NumberFormat extends AbstractHelper
      * @param  string $locale
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale($locale): self
     {
         $this->locale = (string) $locale;
         return $this;
@@ -273,7 +273,7 @@ class NumberFormat extends AbstractHelper
      *
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         if ($this->locale === null) {
             $this->locale = Locale::getDefault();
@@ -285,7 +285,7 @@ class NumberFormat extends AbstractHelper
     /**
      * @return array
      */
-    public function getTextAttributes()
+    public function getTextAttributes(): array
     {
         return $this->textAttributes;
     }
@@ -294,7 +294,7 @@ class NumberFormat extends AbstractHelper
      * @param array $textAttributes
      * @return $this
      */
-    public function setTextAttributes(array $textAttributes)
+    public function setTextAttributes(array $textAttributes): self
     {
         $this->textAttributes = $textAttributes;
         return $this;

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -15,7 +15,7 @@ use function md5;
 use function serialize;
 
 /**
- * View helper for formatting dates.
+ * View helper for formatting numbers.
  */
 class NumberFormat extends AbstractHelper
 {

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -48,6 +48,8 @@ class NumberFormat extends AbstractHelper
 
     /**
      * Text attributes.
+     *
+     * @var array<int, string>
      */
     protected array $textAttributes = [];
 
@@ -59,7 +61,8 @@ class NumberFormat extends AbstractHelper
     /**
      * Format a number
      *
-     * @param  int|float   $number
+     * @param  int|float           $number
+     * @param  array<int, string>  $textAttributes
      */
     public function __invoke(
         $number,
@@ -145,9 +148,9 @@ class NumberFormat extends AbstractHelper
     /**
      * Set format type to use instead of the default
      */
-    public function setFormatType($formatType): self
+    public function setFormatType(?int $formatType): self
     {
-        $this->formatType = (int) $formatType;
+        $this->formatType = $formatType;
         return $this;
     }
 
@@ -235,11 +238,17 @@ class NumberFormat extends AbstractHelper
         return $this->locale;
     }
 
+    /**
+     * @return array<int, string>
+     */
     public function getTextAttributes(): array
     {
         return $this->textAttributes;
     }
 
+    /**
+     * @param array<int, string> $textAttributes
+     */
     public function setTextAttributes(array $textAttributes): self
     {
         $this->textAttributes = $textAttributes;

--- a/src/View/HelperTrait.php
+++ b/src/View/HelperTrait.php
@@ -22,7 +22,7 @@ use IntlDateFormatter;
  * @method string countryCodeDataList(?string $locale = null, array $dataListAttributes = [])
  * @method string currencyFormat(float $number, string|null $currencyCode = null, bool|null $showDecimals = null, string|null $locale = null, string|null $pattern = null)
  * @method string dateFormat(\DateTimeInterface|\IntlCalendar|int|array $date, int $dateType = IntlDateFormatter::NONE, int $timeType = IntlDateFormatter::NONE, string|null $locale = null, string|null $pattern = null)
- * @method string numberFormat(int|float $number, int|null $formatStyle = null, int|null $formatType = null, string|null $locale = null, int|null $decimals = null, array|null $textAttributes = null)
+ * @method string numberFormat(int|float $number, int|null $formatStyle = null, int|null $formatType = null, string|null $locale = null, int|null $maxDecimals = null, array|null $textAttributes = null, int|null $minDecimals = null)
  * @method string plural(array|string $strings, int $number)
  * @method string translate(string $message, string|null $textDomain = null, string|null $locale = null)
  * @method string translatePlural(string $singular, string $plural, int $number, string|null $textDomain = null, string|null $locale = null)

--- a/test/View/Helper/NumberFormatTest.php
+++ b/test/View/Helper/NumberFormatTest.php
@@ -23,7 +23,7 @@ class NumberFormatTest extends TestCase
     }
 
     /** @return array<array-key, array{0: string, 1: int, 2: int, 3: int|null, 4: array<int, string>, 5: float, 6: string}> */
-    public static function currencyTestsDataProvider(): array
+    public static function numberTestsDataProvider(): array
     {
         return [
             [
@@ -32,6 +32,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234567890000,
                 '1.234.567,891',
             ],
@@ -41,6 +42,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 6,
                 [],
+                null,
                 1234567.891234567890000,
                 '1.234.567,891235',
             ],
@@ -50,6 +52,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234567890000,
                 '123.456.789 %',
             ],
@@ -59,6 +62,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 1,
                 [],
+                null,
                 1234567.891234567890000,
                 '123.456.789,1 %',
             ],
@@ -68,6 +72,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234560000,
                 '1,23456789123456E6',
             ],
@@ -77,6 +82,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234567890000,
                 '1 234 567,891',
             ],
@@ -86,6 +92,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234567890000,
                 '123 456 789 %',
             ],
@@ -95,6 +102,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234560000,
                 '1,23456789123456E6',
             ],
@@ -104,6 +112,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234567890000,
                 '1,234,567.891',
             ],
@@ -113,6 +122,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234567890000,
                 '123,456,789%',
             ],
@@ -122,6 +132,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::TYPE_DOUBLE,
                 null,
                 [],
+                null,
                 1234567.891234560000,
                 '1.23456789123456E6',
             ],
@@ -133,8 +144,29 @@ class NumberFormatTest extends TestCase
                 [
                     NumberFormatter::NEGATIVE_PREFIX => 'MINUS',
                 ],
+                null,
                 -1234567.891234567890000,
                 'MINUS123,456,789%',
+            ],
+            [
+                'de_DE',
+                NumberFormatter::DECIMAL,
+                NumberFormatter::TYPE_DOUBLE,
+                5,
+                [],
+                0,
+                1234567.891234567890000,
+                '1.234.567,89123',
+            ],
+            [
+                'de_DE',
+                NumberFormatter::DECIMAL,
+                NumberFormatter::TYPE_DOUBLE,
+                5,
+                [],
+                0,
+                1234567,
+                '1.234.567',
             ],
         ];
     }
@@ -142,13 +174,14 @@ class NumberFormatTest extends TestCase
     /**
      * @param array<int, string> $textAttributes
      */
-    #[DataProvider('currencyTestsDataProvider')]
+    #[DataProvider('numberTestsDataProvider')]
     public function testBasic(
         string $locale,
         int $formatStyle,
         int $formatType,
         ?int $decimals,
         array $textAttributes,
+        ?int $minDecimals,
         float $number,
         string $expected
     ): void {
@@ -158,29 +191,32 @@ class NumberFormatTest extends TestCase
             $formatType,
             $locale,
             $decimals,
-            $textAttributes
+            $textAttributes,
+            $minDecimals
         ));
     }
 
     /**
      * @param array<int, string> $textAttributes
      */
-    #[DataProvider('currencyTestsDataProvider')]
+    #[DataProvider('numberTestsDataProvider')]
     public function testSettersProvideDefaults(
         string $locale,
         int $formatStyle,
         int $formatType,
         ?int $decimals,
         array $textAttributes,
+        ?int $minDecimals,
         float $number,
         string $expected
     ): void {
         $this->helper
              ->setLocale($locale)
              ->setFormatStyle($formatStyle)
-             ->setDecimals($decimals)
+             ->setMaxDecimals($decimals)
              ->setFormatType($formatType)
-             ->setTextAttributes($textAttributes);
+             ->setTextAttributes($textAttributes)
+             ->setMinDecimals($minDecimals);
 
         self::assertMbStringEquals($expected, $this->helper->__invoke($number));
     }

--- a/test/View/Helper/NumberFormatTest.php
+++ b/test/View/Helper/NumberFormatTest.php
@@ -22,7 +22,7 @@ class NumberFormatTest extends TestCase
         $this->helper = new NumberFormatHelper();
     }
 
-    /** @return array<array-key, array{0: string, 1: int, 2: int, 3: int|null, 4: array<int, string>, 5: float, 6: string}> */
+    /** @return array<array-key, array{0: string, 1: int, 2: int, 3: int|null, 4: array<int, string>, 5: int|null, 6: float, 7: string}> */
     public static function numberTestsDataProvider(): array
     {
         return [


### PR DESCRIPTION
Q | A
-- | --
Documentation | no
Bugfix | no
BC Break | no
New Feature | yes
RFC | yes
QA | no


## Description
We have some user provided numbers that may have zero to 
endless decimals. We want to display them in the user locale exactly as 
provided.

If the user inputs "1", we want to display "1". If the user inputs "0,5432" (german notation!) we want to display "0,5432".

Sadly with the current (2.24.1) View-Helper we have to know beforehand how many decimals the user has used.</p>

The underlying NumberFormatter-Class can do this: by 
setting min-decimals to zero and max-decimals to PHP_INT_MAX (or some 
large arbitrary number). The view-helper does not allow to set these 2 
options separatly (yet). Thats what I added.

According to the github-template I should target the 
"develop" branch. Sadly no branch named "develop" can be found in this 
repository, so I've targeted the branch of the currently active minor 
version. Please advice if this was the right approach.

Some commits are optional: adding type hint to variables and classes and may be discard if undesired.