### PR TITLE
Dont set the locale implicitly

### DIFF
--- a/src/View/Helper/CurrencyFormat.php
+++ b/src/View/Helper/CurrencyFormat.php
@@ -212,7 +212,7 @@ class CurrencyFormat extends AbstractHelper
     public function getLocale()
     {
         if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
+            return Locale::getDefault();
         }
 
         return $this->locale;

--- a/src/View/Helper/DateFormat.php
+++ b/src/View/Helper/DateFormat.php
@@ -98,7 +98,7 @@ class DateFormat extends AbstractHelper
     public function getLocale()
     {
         if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
+            return Locale::getDefault();
         }
 
         return $this->locale;

--- a/src/View/Helper/NumberFormat.php
+++ b/src/View/Helper/NumberFormat.php
@@ -214,7 +214,7 @@ class NumberFormat extends AbstractHelper
     public function getLocale()
     {
         if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
+            return Locale::getDefault();
         }
 
         return $this->locale;

--- a/test/View/Helper/CurrencyFormatTest.php
+++ b/test/View/Helper/CurrencyFormatTest.php
@@ -108,4 +108,16 @@ class CurrencyFormatTest extends TestCase
         $test     = str_replace(["\xC2\xA0", ' '], '', $test);
         self::assertEquals($expected, $test, $message);
     }
+
+    public function testNoImplicitLocale(): void
+    {
+        Locale::setDefault('de');
+        self::assertEquals(Locale::getDefault(), $this->helper->getLocale());
+
+        Locale::setDefault('en');
+        self::assertEquals(Locale::getDefault(), $this->helper->getLocale());
+
+        $this->helper->setLocale('es');
+        self::assertEquals('es', $this->helper->getLocale());
+    }
 }

--- a/test/View/Helper/DateFormatTest.php
+++ b/test/View/Helper/DateFormatTest.php
@@ -295,4 +295,16 @@ class DateFormatTest extends TestCase
             $helper->__invoke($calendar, IntlDateFormatter::FULL, IntlDateFormatter::FULL, 'it_IT', 'dd-MM-Y')
         );
     }
+
+    public function testNoImplicitLocale(): void
+    {
+        Locale::setDefault('de');
+        self::assertEquals(Locale::getDefault(), $this->helper->getLocale());
+
+        Locale::setDefault('en');
+        self::assertEquals(Locale::getDefault(), $this->helper->getLocale());
+
+        $this->helper->setLocale('es');
+        self::assertEquals('es', $this->helper->getLocale());
+    }
 }

--- a/test/View/Helper/NumberFormatTest.php
+++ b/test/View/Helper/NumberFormatTest.php
@@ -196,4 +196,16 @@ class NumberFormatTest extends TestCase
         $test     = str_replace(["\xC2\xA0", ' '], '', $test);
         self::assertEquals($expected, $test, $message);
     }
+
+    public function testNoImplicitLocale(): void
+    {
+        Locale::setDefault('de');
+        self::assertEquals(Locale::getDefault(), $this->helper->getLocale());
+
+        Locale::setDefault('en');
+        self::assertEquals(Locale::getDefault(), $this->helper->getLocale());
+
+        $this->helper->setLocale('es');
+        self::assertEquals('es', $this->helper->getLocale());
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes*
| BC Break      | no*
| New Feature   |no
| RFC           | no
| QA            | no

* = my opinion, yours may be different

### Description

On a multi-locale project there may be some use cases where the locale is not fixed but has to be changed for certain actions. e. g. rendering a PDF in multiple languages, pre-rendering a view-script in multiple languages, rendering an email in a background job where no locale is inherently set.

Ideadlly I want to have a single source of truth: `\Locale::getDefault()`. This is used in php-internal functions like the `DateFormatter` and so on, so I can switch the output locale on the fly.

Sadly the view helpers of this module "cache" the locale in their state so I have to go through each and every one that may do this and set the locale explicitly. 

This is hard to debug because the first usage of a specific view helper always uses the correct locale (because `$this->locale` is still `null`), but the second usage of the view helper takes the old `$locale` and not the new.
