### PR TITLE
PSR-16 standard compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
     "require-dev": {
         "laminas/laminas-cache": "^3.12.1",
         "laminas/laminas-cache-storage-adapter-memory": "^2.3.0",
-        "laminas/laminas-cache-storage-deprecated-factory": "^1.2",
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-config": "^3.9.0",
         "laminas/laminas-eventmanager": "^3.13",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-intl": "*",
         "laminas/laminas-servicemanager": "^3.21.0",
-        "laminas/laminas-stdlib": "^3.0"
+        "laminas/laminas-stdlib": "^3.0",
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "laminas/laminas-cache": "^3.12.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e9d1dcf1a7ded07aa7cdfc6056e250c",
+    "content-hash": "34e420973a6a579c4fd6fb930fc5f68b",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -1148,65 +1148,6 @@
                 }
             ],
             "time": "2023-10-18T09:43:33+00:00"
-        },
-        {
-            "name": "laminas/laminas-cache-storage-deprecated-factory",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-cache-storage-deprecated-factory.git",
-                "reference": "276ffbb6c01400fb071d8f6167650e6112d2de2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-deprecated-factory/zipball/276ffbb6c01400fb071d8f6167650e6112d2de2f",
-                "reference": "276ffbb6c01400fb071d8f6167650e6112d2de2f",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-cache": "^3.0",
-                "laminas/laminas-servicemanager": "^3.7",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-                "webmozart/assert": "^1.10"
-            },
-            "require-dev": {
-                "laminas/laminas-cache-storage-adapter-apcu": "^2.4",
-                "laminas/laminas-cache-storage-adapter-blackhole": "^2.2",
-                "laminas/laminas-cache-storage-adapter-ext-mongodb": "^2.3",
-                "laminas/laminas-cache-storage-adapter-filesystem": "^2.3",
-                "laminas/laminas-cache-storage-adapter-memcached": "^2.4",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2",
-                "laminas/laminas-cache-storage-adapter-redis": "^2.5",
-                "laminas/laminas-cache-storage-adapter-session": "^2.3",
-                "laminas/laminas-coding-standard": "2.3",
-                "laminas/laminas-serializer": "^2.14",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Temporary storage adapter factory for fluent migration to laminas-cache v3 when working with laminas components which depend on laminas-cache",
-            "support": {
-                "issues": "https://github.com/laminas/laminas-cache-storage-deprecated-factory/issues",
-                "source": "https://github.com/laminas/laminas-cache-storage-deprecated-factory/tree/1.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-01-08T14:30:59+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31ac363ec8bf003ee6a61b444948f2b2",
+    "content-hash": "0e9d1dcf1a7ded07aa7cdfc6056e250c",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -202,6 +202,57 @@
                 "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
             "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
+            "time": "2017-10-23T01:57:42+00:00"
         }
     ],
     "packages-dev": [
@@ -2909,57 +2960,6 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
             "time": "2021-07-14T16:46:02+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
-            },
-            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/docs/book/translator/caching.md
+++ b/docs/book/translator/caching.md
@@ -4,27 +4,17 @@ In production, it makes sense to cache your translations. This not only saves
 you from loading and parsing the individual formats each time, but also
 guarantees an optimized loading procedure.
 
-> MISSING: **Installation Requirements**
-> The cache support of laminas-i18n depends on the [laminas-cache](https://docs.laminas.dev/laminas-cache/) component, so be sure to have it installed before getting started:
->
-> ```bash
-> $ composer require laminas/laminas-cache
-> ```
->
-> Version 3 of laminas-cache removed support for factories required by this component, so if your application requires laminas-cache version 3 or later, you will also need to install `laminas-cache-storage-deprecated-factory`
->
-> ```bash
-> $ composer require laminas/laminas-cache-storage-deprecated-factory
-> ```
-
 ## Enable Caching
 
-To enable caching, pass a `Laminas\Cache\Storage\Adapter` to the `setCache()`
+To enable caching, pass a `Psr\SimpleCache\CacheInterface` to the `setCache()`
 method.
+
+The following example is based on the use of the
+[laminas-cache](https://docs.laminas.dev/laminas-cache/) component.
 
 ```php
 $translator = new Laminas\I18n\Translator\Translator();
-$cache      = Laminas\Cache\StorageFactory::factory([
+$cacheStorage = Laminas\Cache\StorageFactory::factory([
     'adapter' => [
         'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
         'options' => [
@@ -32,6 +22,7 @@ $cache      = Laminas\Cache\StorageFactory::factory([
         ],
     ],
 ]);
+$cache        = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator(cacheStorage);
 $translator->setCache($cache);
 ```
 

--- a/docs/book/translator/caching.md
+++ b/docs/book/translator/caching.md
@@ -14,16 +14,11 @@ The following example is based on the use of the
 
 ```php
 $translator = new Laminas\I18n\Translator\Translator();
-$cacheStorage = Laminas\Cache\StorageFactory::factory([
-    'adapter' => [
-        'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
-        'options' => [
-            'cache_dir' => __DIR__ . '/cache',
-        ],
-    ],
+$cacheStorage = new Laminas\Cache\Storage\Adapter\Filesystem([
+    'cache_dir' => __DIR__ . '/cache',
 ]);
-$cache        = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator(cacheStorage);
-$translator->setCache($cache);
+$cache = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator($cacheStorage);
+$translator->setCache($cache);``
 ```
 
 The explanation of creating a cache and using different adapters for caching

--- a/docs/book/translator/factory.md
+++ b/docs/book/translator/factory.md
@@ -115,8 +115,12 @@ $translator->getPluginManager()->setService(
 
 ### Using a Cache Instance
 
+The following example is based on the use of the
+[laminas-cache](https://docs.laminas.dev/laminas-cache/) component.
+
 ```php
-$cache      = Laminas\Cache\StorageFactory::factory([
+$translator   = new Laminas\I18n\Translator\Translator();
+$cacheStorage = Laminas\Cache\StorageFactory::factory([
     'adapter' => [
         'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
         'options' => [
@@ -124,23 +128,9 @@ $cache      = Laminas\Cache\StorageFactory::factory([
         ],
     ],
 ]);
+$cache        = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator(cacheStorage);
 $translator = Laminas\I18n\Translator\Translator::factory([
     'cache' => $cache,
-]);
-```
-
-### Using Cache Configuration
-
-```php
-$translator = Laminas\I18n\Translator\Translator::factory([
-    'cache' => [
-        'adapter' => [
-        'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
-            'options' => [
-                'cache_dir' => __DIR__ . '/cache',
-            ],
-        ],
-    ],
 ]);
 ```
 

--- a/docs/book/translator/factory.md
+++ b/docs/book/translator/factory.md
@@ -119,16 +119,11 @@ The following example is based on the use of the
 [laminas-cache](https://docs.laminas.dev/laminas-cache/) component.
 
 ```php
-$translator   = new Laminas\I18n\Translator\Translator();
-$cacheStorage = Laminas\Cache\StorageFactory::factory([
-    'adapter' => [
-        'name'    => Laminas\Cache\Storage\Adapter\Filesystem::class,
-        'options' => [
-            'cache_dir' => __DIR__ . '/cache',
-        ],
-    ],
+$translator = new Laminas\I18n\Translator\Translator();
+$cacheStorage = new Laminas\Cache\Storage\Adapter\Filesystem([
+    'cache_dir' => __DIR__ . '/cache',
 ]);
-$cache        = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator(cacheStorage);
+$cache = new Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator($cacheStorage);
 $translator = Laminas\I18n\Translator\Translator::factory([
     'cache' => $cache,
 ]);

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -16,8 +16,10 @@ use Traversable;
 
 use function array_shift;
 use function get_debug_type;
+use function gettype;
 use function is_array;
 use function is_file;
+use function is_object;
 use function is_string;
 use function md5;
 use function rtrim;
@@ -219,12 +221,12 @@ class Translator implements TranslatorInterface
 
         // cache
         if (isset($options['cache'])) {
-            if (! ($options['cache'] instanceof CacheInterface)) {
+            if (! $options['cache'] instanceof CacheInterface) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     '%s expects a %s instance; received "%s"',
                     __METHOD__,
                     CacheInterface::class,
-                    (is_object($options) ? get_class($options) : gettype($options))
+                    is_object($options) ? $options::class : gettype($options)
                 ));
             }
                 $translator->setCache($options['cache']);
@@ -291,7 +293,6 @@ class Translator implements TranslatorInterface
     /**
      * Sets a cache
      *
-     * @param  CacheInterface|null $cache
      * @return $this
      */
     public function setCache(?CacheInterface $cache = null)
@@ -503,7 +504,7 @@ class Translator implements TranslatorInterface
         }
 
         $this->files[$textDomain][$locale][] = [
-            'type' => $type,
+            'type'     => $type,
             'filename' => $filename,
         ];
 

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -2,8 +2,6 @@
 
 namespace Laminas\I18n\Translator;
 
-use Laminas\Cache;
-use Laminas\Cache\Storage\StorageInterface as CacheStorage;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
@@ -13,6 +11,7 @@ use Laminas\I18n\Translator\Loader\RemoteLoaderInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Locale;
+use Psr\SimpleCache\CacheInterface;
 use Traversable;
 
 use function array_shift;
@@ -84,7 +83,7 @@ class Translator implements TranslatorInterface
     /**
      * Translation cache.
      *
-     * @var CacheStorage|null
+     * @var CacheInterface|null
      */
     protected $cache;
 
@@ -220,11 +219,15 @@ class Translator implements TranslatorInterface
 
         // cache
         if (isset($options['cache'])) {
-            if ($options['cache'] instanceof CacheStorage) {
-                $translator->setCache($options['cache']);
-            } else {
-                $translator->setCache(Cache\StorageFactory::factory($options['cache']));
+            if (! ($options['cache'] instanceof CacheInterface)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    '%s expects a %s instance; received "%s"',
+                    __METHOD__,
+                    CacheInterface::class,
+                    (is_object($options) ? get_class($options) : gettype($options))
+                ));
             }
+                $translator->setCache($options['cache']);
         }
 
         // event manager enabled
@@ -288,9 +291,10 @@ class Translator implements TranslatorInterface
     /**
      * Sets a cache
      *
+     * @param  CacheInterface|null $cache
      * @return $this
      */
-    public function setCache(?CacheStorage $cache = null)
+    public function setCache(?CacheInterface $cache = null)
     {
         $this->cache = $cache;
 
@@ -300,7 +304,7 @@ class Translator implements TranslatorInterface
     /**
      * Returns the set cache
      *
-     * @return CacheStorage|null The set cache
+     * @return CacheInterface|null The set cache
      */
     public function getCache()
     {
@@ -499,7 +503,7 @@ class Translator implements TranslatorInterface
         }
 
         $this->files[$textDomain][$locale][] = [
-            'type'     => $type,
+            'type' => $type,
             'filename' => $filename,
         ];
 
@@ -561,7 +565,7 @@ class Translator implements TranslatorInterface
      */
     public function getCacheId($textDomain, $locale)
     {
-        return 'Laminas_I18n_Translator_Messages_' . md5($textDomain . $locale);
+        return 'Laminas_I18n_Translator_Msg_' . md5($textDomain . $locale);
     }
 
     /**
@@ -576,7 +580,7 @@ class Translator implements TranslatorInterface
         if (null === ($cache = $this->getCache())) {
             return false;
         }
-        return $cache->removeItem($this->getCacheId($textDomain, $locale));
+        return $cache->delete($this->getCacheId($textDomain, $locale));
     }
 
     /**
@@ -597,7 +601,7 @@ class Translator implements TranslatorInterface
         if (null !== ($cache = $this->getCache())) {
             $cacheId = $this->getCacheId($textDomain, $locale);
 
-            if (null !== ($result = $cache->getItem($cacheId))) {
+            if (null !== ($result = $cache->get($cacheId))) {
                 $this->messages[$textDomain][$locale] = $result;
 
                 return;
@@ -631,7 +635,7 @@ class Translator implements TranslatorInterface
         }
 
         if ($cache !== null) {
-            $cache->setItem($cacheId, $this->messages[$textDomain][$locale]);
+            $cache->set($cacheId, $this->messages[$textDomain][$locale]);
         }
     }
 

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -16,10 +16,8 @@ use Traversable;
 
 use function array_shift;
 use function get_debug_type;
-use function gettype;
 use function is_array;
 use function is_file;
-use function is_object;
 use function is_string;
 use function md5;
 use function rtrim;

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -221,15 +221,7 @@ class Translator implements TranslatorInterface
 
         // cache
         if (isset($options['cache'])) {
-            if (! $options['cache'] instanceof CacheInterface) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    '%s expects a %s instance; received "%s"',
-                    __METHOD__,
-                    CacheInterface::class,
-                    is_object($options) ? $options::class : gettype($options)
-                ));
-            }
-                $translator->setCache($options['cache']);
+            $translator->setCache($options['cache']);
         }
 
         // event manager enabled

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -139,7 +139,7 @@ class TranslatorTest extends TestCase
         ]);
 
         self::assertInstanceOf(Translator::class, $translator);
-        $this->assertEquals($cache, $translator->getCache());
+        $this->assertSame($cache, $translator->getCache());
     }
 
     public function testDefaultLocale(): void

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace LaminasTest\I18n\Translator;
 
+use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 use Laminas\Cache\StorageFactory as CacheFactory;
 use Laminas\EventManager\Event;
-use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 use Laminas\EventManager\EventInterface;
 use Laminas\I18n\Translator\TextDomain;
 use Laminas\I18n\Translator\Translator;
@@ -23,7 +23,7 @@ class TranslatorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->translator     = new Translator();
+        $this->translator = new Translator();
         Locale::setDefault('en_EN');
         $this->testFilesDir = __DIR__ . '/_files';
     }
@@ -31,17 +31,17 @@ class TranslatorTest extends TestCase
     public function testFactoryCreatesTranslator(): void
     {
         $translator = Translator::factory([
-            'locale' => 'de_DE',
+            'locale'   => 'de_DE',
             'patterns' => [
                 [
-                    'type' => 'phparray',
+                    'type'     => 'phparray',
                     'base_dir' => $this->testFilesDir . '/testarray',
                     'pattern'  => 'translation-%s.php',
                 ],
             ],
-            'files' => [
+            'files'    => [
                 [
-                    'type' => 'phparray',
+                    'type'     => 'phparray',
                     'filename' => $this->testFilesDir . '/translation_en.php',
                 ],
             ],
@@ -54,15 +54,15 @@ class TranslatorTest extends TestCase
     public function testTranslationFromSeveralTranslationFiles(): void
     {
         $translator = Translator::factory([
-            'locale' => 'de_DE',
+            'locale'                    => 'de_DE',
             'translation_file_patterns' => [
                 [
-                    'type' => 'phparray',
+                    'type'     => 'phparray',
                     'base_dir' => $this->testFilesDir . '/testarray',
                     'pattern'  => 'translation-%s.php',
                 ],
                 [
-                    'type' => 'phparray',
+                    'type'     => 'phparray',
                     'base_dir' => $this->testFilesDir . '/testarray',
                     'pattern'  => 'translation-more-%s.php',
                 ],
@@ -102,7 +102,7 @@ class TranslatorTest extends TestCase
     public function testTranslationFromDifferentSourceTypes(): void
     {
         $translator = Translator::factory([
-            'locale' => 'de_DE',
+            'locale'                    => 'de_DE',
             'translation_file_patterns' => [
                 [
                     'type'     => 'phparray',
@@ -110,7 +110,7 @@ class TranslatorTest extends TestCase
                     'pattern'  => 'translation-de_DE.php',
                 ],
             ],
-            'translation_files' => [
+            'translation_files'         => [
                 [
                     'type'     => 'phparray',
                     'filename' => $this->testFilesDir . '/testarray/translation-more-de_DE.php',
@@ -127,15 +127,15 @@ class TranslatorTest extends TestCase
         $cache = new SimpleCacheDecorator(CacheFactory::factory(['adapter' => 'memory']));
 
         $translator = Translator::factory([
-            'locale' => 'de_DE',
+            'locale'   => 'de_DE',
             'patterns' => [
                 [
-                    'type' => 'phparray',
+                    'type'     => 'phparray',
                     'base_dir' => $this->testFilesDir . '/testarray',
                     'pattern'  => 'translation-%s.php',
                 ],
             ],
-            'cache' => $cache,
+            'cache'    => $cache,
         ]);
 
         self::assertInstanceOf(Translator::class, $translator);
@@ -155,14 +155,14 @@ class TranslatorTest extends TestCase
 
     public function testTranslate(): void
     {
-        $loader = new TestLoader();
+        $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $config = new Config([
+        $config             = new Config([
             'services' => [
                 'test' => $loader,
             ],
         ]);
-        $pm = $this->translator->getPluginManager();
+        $pm                 = $this->translator->getPluginManager();
         $config->configureServiceManager($pm);
         $this->translator->setPluginManager($pm);
         $this->translator->addTranslationFile('test', null);
@@ -188,10 +188,10 @@ class TranslatorTest extends TestCase
         $cache = new SimpleCacheDecorator(CacheFactory::factory(['adapter' => 'memory']));
         $this->translator->setCache($cache);
 
-        $loader = new TestLoader();
+        $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $config = new Config(['services' => ['test' => $loader]]);
-        $plugins = $this->translator->getPluginManager();
+        $config             = new Config(['services' => ['test' => $loader]]);
+        $plugins            = $this->translator->getPluginManager();
         $config->configureServiceManager($plugins);
         $this->translator->setPluginManager($plugins);
         $this->translator->addTranslationFile('test', null);
@@ -397,7 +397,7 @@ class TranslatorTest extends TestCase
 
     public function testListenerOnMissingTranslationEventCanReturnString(): void
     {
-        $trigger     = null;
+        $trigger      = null;
         $doNotTrigger = null;
 
         $this->translator->enableEventManager();
@@ -534,14 +534,14 @@ class TranslatorTest extends TestCase
 
     public function testNullMessageArgumentShouldReturnAnEmptyString(): void
     {
-        $loader = new TestLoader();
+        $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
         $config             = new Config([
             'services' => [
                 'test' => $loader,
             ],
         ]);
-        $pm = $this->translator->getPluginManager();
+        $pm                 = $this->translator->getPluginManager();
         $config->configureServiceManager($pm);
         $this->translator->setPluginManager($pm);
         $this->translator->addTranslationFile('test', null);

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\I18n\Translator;
 
 use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
-use Laminas\Cache\StorageFactory as CacheFactory;
+use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
 use Laminas\I18n\Translator\TextDomain;
@@ -124,7 +124,7 @@ class TranslatorTest extends TestCase
 
     public function testFactoryCreatesTranslatorWithCache(): void
     {
-        $cache = new SimpleCacheDecorator(CacheFactory::factory(['adapter' => 'memory']));
+        $cache = new SimpleCacheDecorator(new Memory());
 
         $translator = Translator::factory([
             'locale'   => 'de_DE',
@@ -172,7 +172,7 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsLoadedFromCache(): void
     {
-        $cache = new SimpleCacheDecorator(CacheFactory::factory(['adapter' => 'memory']));
+        $cache = new SimpleCacheDecorator(new Memory());
         $this->translator->setCache($cache);
 
         $cache->set(
@@ -185,7 +185,7 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsAreStoredInCache(): void
     {
-        $cache = new SimpleCacheDecorator(CacheFactory::factory(['adapter' => 'memory']));
+        $cache = new SimpleCacheDecorator(new Memory());
         $this->translator->setCache($cache);
 
         $loader             = new TestLoader();
@@ -208,7 +208,7 @@ class TranslatorTest extends TestCase
         $textDomain = 'default';
         $locale     = 'en_EN';
 
-        $cache = new SimpleCacheDecorator(CacheFactory::factory(['adapter' => 'memory']));
+        $cache = new SimpleCacheDecorator(new Memory());
         $this->translator->setCache($cache);
 
         $cache->set(


### PR DESCRIPTION
Closes #49

<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This is a revival of https://github.com/laminas/laminas-i18n/pull/50, to bring support for PSR-16, and with the goal to release as a major version.

I think the decorator pattern suggested in #50 is a bit too cumbersome for a feature that is supposed to be used very often. Keeping things well-integrated in the `Translator` class keep it simple to use, and dropping support for `CacheStorage` makes maintenance easier. Both of those decisions seems to be the best for the long term, even though it requires a major version.