### PR TITLE
`Laminas\Translator`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-intl": "*",
         "laminas/laminas-servicemanager": "^3.21.0",
-        "laminas/laminas-stdlib": "^3.0"
+        "laminas/laminas-stdlib": "^3.0",
+        "laminas/laminas-translator": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-cache": "^3.12.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31ac363ec8bf003ee6a61b444948f2b2",
+    "content-hash": "589961f1746a8e94e4442bcfdb401934",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -154,6 +154,59 @@
                 }
             ],
             "time": "2024-01-19T12:39:49+00:00"
+        },
+        {
+            "name": "laminas/laminas-translator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "86d176c01a96b0ef205192b776cb69e8d4ca06b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/86d176c01a96b0ef205192b776cb69e8d4ca06b1",
+                "reference": "86d176c01a96b0ef205192b776cb69e8d4ca06b1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-06-18T15:09:24+00:00"
         },
         {
             "name": "psr/container",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/ConfigProvider.php">
     <DeprecatedClass>
       <code><![CDATA[Validator\PhoneNumber::class]]></code>
@@ -332,6 +332,9 @@
     </PossiblyNullReference>
   </file>
   <file src="src/Translator/Translator.php">
+    <DeprecatedInterface>
+      <code><![CDATA[Translator]]></code>
+    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code><![CDATA[$message === null]]></code>
       <code><![CDATA[$message === null]]></code>
@@ -444,6 +447,10 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Translator/TranslatorAwareInterface.php">
+    <DeprecatedInterface>
+      <code><![CDATA[TranslatorInterface|null]]></code>
+      <code><![CDATA[TranslatorInterface|null]]></code>
+    </DeprecatedInterface>
     <PossiblyUnusedMethod>
       <code><![CDATA[hasTranslator]]></code>
       <code><![CDATA[setTranslatorEnabled]]></code>
@@ -452,6 +459,13 @@
       <code><![CDATA[$this]]></code>
       <code><![CDATA[$this]]></code>
     </PossiblyUnusedReturnValue>
+  </file>
+  <file src="src/Translator/TranslatorAwareTrait.php">
+    <DeprecatedInterface>
+      <code><![CDATA[?TranslatorInterface]]></code>
+      <code><![CDATA[TranslatorInterface|null]]></code>
+      <code><![CDATA[TranslatorInterface|null]]></code>
+    </DeprecatedInterface>
   </file>
   <file src="src/Translator/TranslatorServiceFactory.php">
     <DeprecatedInterface>
@@ -575,6 +589,11 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/View/Helper/AbstractTranslatorHelper.php">
+    <DeprecatedInterface>
+      <code><![CDATA[Translator|null]]></code>
+      <code><![CDATA[Translator|null]]></code>
+      <code><![CDATA[Translator|null]]></code>
+    </DeprecatedInterface>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $enabled]]></code>
     </RedundantCastGivenDocblockType>

--- a/src/Translator/TranslatorInterface.php
+++ b/src/Translator/TranslatorInterface.php
@@ -6,6 +6,9 @@ use Laminas\Translator\TranslatorInterface as Translator;
 
 /**
  * Translator interface.
+ *
+ * @deprecated Since 2.27.0 The translator interface is now in a separate package `laminas/laminas-translator` and this
+ *             interface should be replaced by `Laminas\Translator\TranslatorInterface`
  */
 interface TranslatorInterface extends Translator
 {

--- a/src/Translator/TranslatorInterface.php
+++ b/src/Translator/TranslatorInterface.php
@@ -2,36 +2,11 @@
 
 namespace Laminas\I18n\Translator;
 
+use Laminas\Translator\TranslatorInterface as Translator;
+
 /**
  * Translator interface.
  */
-interface TranslatorInterface
+interface TranslatorInterface extends Translator
 {
-    /**
-     * Translate a message.
-     *
-     * @param  string $message
-     * @param  string $textDomain
-     * @param  string $locale
-     * @return string
-     */
-    public function translate($message, $textDomain = 'default', $locale = null);
-
-    /**
-     * Translate a plural message.
-     *
-     * @param  string      $singular
-     * @param  string      $plural
-     * @param  int         $number
-     * @param  string      $textDomain
-     * @param  string|null $locale
-     * @return string
-     */
-    public function translatePlural(
-        $singular,
-        $plural,
-        $number,
-        $textDomain = 'default',
-        $locale = null
-    );
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes


### Description

Requires `laminas/laminas-translator` and extends the shipped interface via `Laminas\I18n\Translator\TranslatorInterface`

As a straight copy of the existing interface, there's no BC break, but I guess there is a "technical" BC break because of any change in inheritance.

If this *has* to go into a major release, it defeats the point of extracting the interface in the first place.

