### PR TITLE
Add service manager alias for `Laminas\Translator\TranslatorInterface`

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -2,14 +2,12 @@
 
 namespace Laminas\I18n;
 
-use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\ServiceManager;
 use Laminas\Translator\TranslatorInterface;
 
 /**
- * @see ConfigInterface
- *
- * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  * @final
  */
 class ConfigProvider
@@ -18,10 +16,10 @@ class ConfigProvider
      * Return general-purpose laminas-i18n configuration.
      *
      * @return array{
-     *     dependencies: ServiceManagerConfigurationType,
-     *     filters: ServiceManagerConfigurationType,
-     *     validators: ServiceManagerConfigurationType,
-     *     view_helpers: ServiceManagerConfigurationType,
+     *     dependencies: ServiceManagerConfiguration,
+     *     filters: ServiceManagerConfiguration,
+     *     validators: ServiceManagerConfiguration,
+     *     view_helpers: ServiceManagerConfiguration,
      *     locale: string|null,
      * }
      */
@@ -39,7 +37,7 @@ class ConfigProvider
     /**
      * Return application-level dependency configuration.
      *
-     * @return ServiceManagerConfigurationType
+     * @return ServiceManagerConfiguration
      */
     public function getDependencyConfig()
     {
@@ -64,7 +62,7 @@ class ConfigProvider
     /**
      * Return laminas-filter configuration.
      *
-     * @return ServiceManagerConfigurationType
+     * @return ServiceManagerConfiguration
      */
     public function getFilterConfig()
     {
@@ -99,7 +97,7 @@ class ConfigProvider
     /**
      * Return laminas-validator configuration.
      *
-     * @return ServiceManagerConfigurationType
+     * @return ServiceManagerConfiguration
      */
     public function getValidatorConfig()
     {
@@ -155,7 +153,7 @@ class ConfigProvider
      *
      * Obsoletes View\HelperConfig.
      *
-     * @return ServiceManagerConfigurationType
+     * @return ServiceManagerConfiguration
      */
     public function getViewHelperConfig()
     {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,6 +4,7 @@ namespace Laminas\I18n;
 
 use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\Translator\TranslatorInterface;
 
 /**
  * @see ConfigInterface
@@ -50,6 +51,7 @@ class ConfigProvider
                 'Zend\I18n\Translator\TranslatorInterface' => Translator\TranslatorInterface::class,
                 'Zend\I18n\Translator\LoaderPluginManager' => Translator\LoaderPluginManager::class,
                 Geography\CountryCodeListInterface::class  => Geography\DefaultCountryCodeList::class,
+                TranslatorInterface::class                 => Translator\TranslatorInterface::class,
             ],
             'factories' => [
                 Translator\TranslatorInterface::class   => Translator\TranslatorServiceFactory::class,

--- a/src/Module.php
+++ b/src/Module.php
@@ -3,12 +3,10 @@
 namespace Laminas\I18n;
 
 use Laminas\ModuleManager\ModuleManager;
-use Laminas\ServiceManager\ConfigInterface;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
- * @see ConfigInterface
- *
- * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
 class Module
 {
@@ -16,10 +14,10 @@ class Module
      * Return laminas-i18n configuration for laminas-mvc application.
      *
      * @return array{
-     *     filters: ServiceManagerConfigurationType,
-     *     service_manager: ServiceManagerConfigurationType,
-     *     validators: ServiceManagerConfigurationType,
-     *     view_helpers: ServiceManagerConfigurationType,
+     *     filters: ServiceManagerConfiguration,
+     *     service_manager: ServiceManagerConfiguration,
+     *     validators: ServiceManagerConfiguration,
+     *     view_helpers: ServiceManagerConfiguration,
      * }
      */
     public function getConfig()


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Adds missing alias for `Laminas\Translator\TranslatorInterface` to the config provider and module that should have been added in #128

Closes #129 