### PR TITLE
Deprecate runtime mutation of validator options

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -564,16 +564,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
+                "reference": "8536c1b9103405bcbd310c69e7a5739a1c2b1f0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "url": "https://api.github.com/repos/composer/semver/zipball/8536c1b9103405bcbd310c69e7a5739a1c2b1f0b",
+                "reference": "8536c1b9103405bcbd310c69e7a5739a1c2b1f0b",
                 "shasum": ""
             },
             "require": {
@@ -625,7 +625,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.0"
+                "source": "https://github.com/composer/semver/tree/3.4.1"
             },
             "funding": [
                 {
@@ -641,7 +641,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T09:50:34+00:00"
+            "time": "2024-07-12T09:13:09+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1606,16 +1606,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.60.0",
+            "version": "2.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "66ab091fc08a8b1e2851eec62dda4bafa977fe9c"
+                "reference": "df77732fbfab331647a5e718d171507269e73b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/66ab091fc08a8b1e2851eec62dda4bafa977fe9c",
-                "reference": "66ab091fc08a8b1e2851eec62dda4bafa977fe9c",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/df77732fbfab331647a5e718d171507269e73b6c",
+                "reference": "df77732fbfab331647a5e718d171507269e73b6c",
                 "shasum": ""
             },
             "require": {
@@ -1686,7 +1686,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-06-25T20:11:22+00:00"
+            "time": "2024-07-11T21:26:44+00:00"
         },
         {
             "name": "laminas/laminas-view",
@@ -2605,16 +2605,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.25",
+            "version": "10.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "831bf82312be6037e811833ddbea0b8de60ea314"
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/831bf82312be6037e811833ddbea0b8de60ea314",
-                "reference": "831bf82312be6037e811833ddbea0b8de60ea314",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2425f713b2a5350568ccb1a2d3984841a23e83c5",
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5",
                 "shasum": ""
             },
             "require": {
@@ -2624,26 +2624,26 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "phpunit/php-code-coverage": "^10.1.15",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.1",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -2686,7 +2686,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.27"
             },
             "funding": [
                 {
@@ -2702,7 +2702,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:49:17+00:00"
+            "time": "2024-07-10T11:48:06+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -484,21 +484,41 @@
     </MixedAssignment>
   </file>
   <file src="src/Validator/Alnum.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAllowWhiteSpace]]></code>
+    </DeprecatedMethod>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $allowWhiteSpace]]></code>
       <code><![CDATA[(bool) $allowWhiteSpace]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Validator/Alpha.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAllowWhiteSpace]]></code>
+    </DeprecatedMethod>
     <InvalidClassConstantType>
       <code><![CDATA[INVALID]]></code>
       <code><![CDATA[STRING_EMPTY]]></code>
     </InvalidClassConstantType>
+    <InvalidExtendClass>
+      <code><![CDATA[Alnum]]></code>
+    </InvalidExtendClass>
+    <MethodSignatureMismatch>
+      <code><![CDATA[public function isValid($value)]]></code>
+    </MethodSignatureMismatch>
     <NonInvariantDocblockPropertyType>
       <code><![CDATA[$filter]]></code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/Validator/DateTime.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getDateType]]></code>
+      <code><![CDATA[getLocale]]></code>
+      <code><![CDATA[getTimeType]]></code>
+      <code><![CDATA[setCalendar]]></code>
+      <code><![CDATA[setPattern]]></code>
+      <code><![CDATA[setTimezone]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($value)]]></code>
     </DocblockTypeContradiction>
@@ -517,11 +537,21 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Validator/IsFloat.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getLocale]]></code>
+      <code><![CDATA[getLocale]]></code>
+      <code><![CDATA[setLocale]]></code>
+    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$options['locale']]]></code>
     </MixedArgument>
   </file>
   <file src="src/Validator/IsInt.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getLocale]]></code>
+      <code><![CDATA[setLocale]]></code>
+      <code><![CDATA[setStrict]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_bool($strict)]]></code>
     </DocblockTypeContradiction>
@@ -563,7 +593,13 @@
   </file>
   <file src="src/Validator/PostCode.php">
     <DeprecatedMethod>
+      <code><![CDATA[getFormat]]></code>
+      <code><![CDATA[getLocale]]></code>
       <code><![CDATA[getService]]></code>
+      <code><![CDATA[setFormat]]></code>
+      <code><![CDATA[setLocale]]></code>
+      <code><![CDATA[setLocale]]></code>
+      <code><![CDATA[setOptions]]></code>
       <code><![CDATA[setService]]></code>
     </DeprecatedMethod>
     <MixedArgument>

--- a/src/Validator/Alnum.php
+++ b/src/Validator/Alnum.php
@@ -12,6 +12,7 @@ use function is_int;
 use function is_scalar;
 use function is_string;
 
+/** @final */
 class Alnum extends AbstractValidator
 {
     public const INVALID      = 'alnumInvalid';
@@ -28,7 +29,7 @@ class Alnum extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $messageTemplates = [
         self::INVALID      => 'Invalid type given. String, integer or float expected',
@@ -63,6 +64,8 @@ class Alnum extends AbstractValidator
     /**
      * Returns the allowWhiteSpace option
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return bool
      */
     public function getAllowWhiteSpace()
@@ -73,7 +76,9 @@ class Alnum extends AbstractValidator
     /**
      * Sets the allowWhiteSpace option
      *
-     * @param  bool $allowWhiteSpace
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
+     * @param bool $allowWhiteSpace
      * @return $this
      */
     public function setAllowWhiteSpace($allowWhiteSpace)

--- a/src/Validator/Alpha.php
+++ b/src/Validator/Alpha.php
@@ -6,6 +6,7 @@ use Laminas\I18n\Filter\Alpha as AlphaFilter;
 
 use function is_string;
 
+/** @final */
 class Alpha extends Alnum
 {
     public const INVALID      = 'alphaInvalid';
@@ -22,7 +23,7 @@ class Alpha extends Alnum
     /**
      * Validation failure message template definitions
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $messageTemplates = [
         self::INVALID      => 'Invalid type given. String expected',

--- a/src/Validator/DateTime.php
+++ b/src/Validator/DateTime.php
@@ -12,6 +12,7 @@ use function date_default_timezone_get;
 use function intl_is_failure;
 use function is_string;
 
+/** @final */
 class DateTime extends AbstractValidator
 {
     public const INVALID          = 'datetimeInvalid';
@@ -89,6 +90,8 @@ class DateTime extends AbstractValidator
     /**
      * Sets the calendar to be used by the IntlDateFormatter
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
      * @param int|null $calendar
      * @return $this
      */
@@ -101,6 +104,8 @@ class DateTime extends AbstractValidator
 
     /**
      * Returns the calendar to by the IntlDateFormatter
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
      *
      * @return int|null
      */
@@ -116,6 +121,8 @@ class DateTime extends AbstractValidator
     /**
      * Sets the date format to be used by the IntlDateFormatter
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
      * @param int|null $dateType
      * @return $this
      */
@@ -130,6 +137,8 @@ class DateTime extends AbstractValidator
     /**
      * Returns the date format used by the IntlDateFormatter
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return int|null
      */
     public function getDateType()
@@ -139,6 +148,8 @@ class DateTime extends AbstractValidator
 
     /**
      * Sets the pattern to be used by the IntlDateFormatter
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
      *
      * @param string|null $pattern
      * @return $this
@@ -152,6 +163,8 @@ class DateTime extends AbstractValidator
 
     /**
      * Returns the pattern used by the IntlDateFormatter
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
      *
      * @return string|null
      */
@@ -167,6 +180,8 @@ class DateTime extends AbstractValidator
     /**
      * Sets the time format to be used by the IntlDateFormatter
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
      * @param int|null $timeType
      * @return $this
      */
@@ -181,6 +196,8 @@ class DateTime extends AbstractValidator
     /**
      * Returns the time format used by the IntlDateFormatter
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return int|null
      */
     public function getTimeType()
@@ -190,6 +207,8 @@ class DateTime extends AbstractValidator
 
     /**
      * Sets the timezone to be used by the IntlDateFormatter
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
      *
      * @param string|null $timezone
      * @return $this
@@ -203,6 +222,8 @@ class DateTime extends AbstractValidator
 
     /**
      * Returns the timezone used by the IntlDateFormatter or the system default if none given
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
      *
      * @return string|null
      */
@@ -218,6 +239,8 @@ class DateTime extends AbstractValidator
     /**
      * Sets the locale to be used by the IntlDateFormatter
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
      * @param string|null $locale
      * @return $this
      */
@@ -231,6 +254,8 @@ class DateTime extends AbstractValidator
 
     /**
      * Returns the locale used by the IntlDateFormatter or the system default if none given
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
      *
      * @return string|null
      */

--- a/src/Validator/IsFloat.php
+++ b/src/Validator/IsFloat.php
@@ -23,6 +23,7 @@ use function preg_match;
 use function preg_quote;
 use function str_replace;
 
+/** @final */
 class IsFloat extends AbstractValidator
 {
     public const INVALID   = 'floatInvalid';
@@ -31,7 +32,7 @@ class IsFloat extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $messageTemplates = [
         self::INVALID   => 'Invalid type given. String, integer or float expected',
@@ -75,6 +76,8 @@ class IsFloat extends AbstractValidator
     /**
      * Returns the set locale
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return string
      */
     public function getLocale()
@@ -87,6 +90,8 @@ class IsFloat extends AbstractValidator
 
     /**
      * Sets the locale to use
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
      *
      * @param string|null $locale
      * @return $this

--- a/src/Validator/IsInt.php
+++ b/src/Validator/IsInt.php
@@ -18,6 +18,7 @@ use function is_int;
 use function is_string;
 use function strtr;
 
+/** @final */
 class IsInt extends AbstractValidator
 {
     public const INVALID        = 'intInvalid';
@@ -27,7 +28,7 @@ class IsInt extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $messageTemplates = [
         self::INVALID        => 'Invalid type given. String or integer expected',
@@ -75,6 +76,8 @@ class IsInt extends AbstractValidator
     /**
      * Returns the set locale
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return string|null
      */
     public function getLocale()
@@ -88,7 +91,9 @@ class IsInt extends AbstractValidator
     /**
      * Sets the locale to use
      *
-     * @param  string|null $locale
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
+     * @param string|null $locale
      * @return $this
      */
     public function setLocale($locale)
@@ -100,6 +105,8 @@ class IsInt extends AbstractValidator
     /**
      * Returns the strict option
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return bool
      */
     public function getStrict()
@@ -109,6 +116,8 @@ class IsInt extends AbstractValidator
 
     /**
      * Sets the strict option mode
+     *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
      *
      * @param bool $strict
      * @return $this

--- a/src/Validator/PostCode.php
+++ b/src/Validator/PostCode.php
@@ -16,6 +16,7 @@ use function is_string;
 use function preg_match;
 use function strlen;
 
+/** @final */
 class PostCode extends AbstractValidator
 {
     public const INVALID        = 'postcodeInvalid';
@@ -26,7 +27,7 @@ class PostCode extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $messageTemplates = [
         self::INVALID        => 'Invalid type given. String or integer expected',
@@ -257,6 +258,8 @@ class PostCode extends AbstractValidator
     /**
      * Returns the set locale
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return string|null The set locale
      */
     public function getLocale()
@@ -267,7 +270,9 @@ class PostCode extends AbstractValidator
     /**
      * Sets the locale to use
      *
-     * @param  string|null $locale
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
+     * @param string|null $locale
      * @return $this
      */
     public function setLocale($locale)
@@ -279,6 +284,8 @@ class PostCode extends AbstractValidator
     /**
      * Returns the set postal code format
      *
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0
+     *
      * @return string|null
      */
     public function getFormat()
@@ -289,7 +296,9 @@ class PostCode extends AbstractValidator
     /**
      * Sets a self defined postal format as regex
      *
-     * @param  string|null $format
+     * @deprecated Since 2.28.0 - This method will be removed in 3.0. Provide options to the constructor instead.
+     *
+     * @param string|null $format
      * @return $this
      */
     public function setFormat($format)


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

As per deprecations in `laminas-validator@2.60+`, this patch deprecates runtime mutation of options here and baselines the deprecation issues.
