### PR TITLE
Reduce use of deprecated Laminas\ServiceManager\ConfigInterface

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -166,9 +166,6 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->creationOptions]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedClass>
-      <code><![CDATA[new Config($config['translator_plugins'])]]></code>
-    </DeprecatedClass>
     <DeprecatedInterface>
       <code><![CDATA[LoaderPluginManagerFactory]]></code>
     </DeprecatedInterface>
@@ -876,19 +873,6 @@
     </PossiblyNullReference>
   </file>
   <file src="test/Translator/TranslatorTest.php">
-    <DeprecatedClass>
-      <code><![CDATA[new Config([
-            'services' => [
-                'test' => $loader,
-            ],
-        ])]]></code>
-      <code><![CDATA[new Config([
-            'services' => [
-                'test' => $loader,
-            ],
-        ])]]></code>
-      <code><![CDATA[new Config(['services' => ['test' => $loader]])]]></code>
-    </DeprecatedClass>
     <NullArgument>
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>

--- a/src/Translator/LoaderPluginManagerFactory.php
+++ b/src/Translator/LoaderPluginManagerFactory.php
@@ -2,7 +2,6 @@
 
 namespace Laminas\I18n\Translator;
 
-use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
@@ -55,7 +54,7 @@ class LoaderPluginManagerFactory implements FactoryInterface
         }
 
         // Wire service configuration for translator_plugins
-        (new Config($config['translator_plugins']))->configureServiceManager($pluginManager);
+        $pluginManager->configure($config['translator_plugins']);
 
         return $pluginManager;
     }

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -10,7 +10,6 @@ use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
 use Laminas\I18n\Translator\TextDomain;
 use Laminas\I18n\Translator\Translator;
-use Laminas\ServiceManager\Config;
 use LaminasTest\I18n\TestCase;
 use LaminasTest\I18n\Translator\TestAsset\Loader as TestLoader;
 use Locale;
@@ -157,13 +156,12 @@ class TranslatorTest extends TestCase
     {
         $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $config             = new Config([
+        $pm                 = $this->translator->getPluginManager();
+        $pm->configure([
             'services' => [
                 'test' => $loader,
             ],
         ]);
-        $pm                 = $this->translator->getPluginManager();
-        $config->configureServiceManager($pm);
         $this->translator->setPluginManager($pm);
         $this->translator->addTranslationFile('test', null);
 
@@ -190,9 +188,8 @@ class TranslatorTest extends TestCase
 
         $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $config             = new Config(['services' => ['test' => $loader]]);
         $plugins            = $this->translator->getPluginManager();
-        $config->configureServiceManager($plugins);
+        $plugins->configure(['services' => ['test' => $loader]]);
         $this->translator->setPluginManager($plugins);
         $this->translator->addTranslationFile('test', null);
 
@@ -537,13 +534,12 @@ class TranslatorTest extends TestCase
     {
         $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $config             = new Config([
+        $pm                 = $this->translator->getPluginManager();
+        $pm->configure([
             'services' => [
                 'test' => $loader,
             ],
         ]);
-        $pm                 = $this->translator->getPluginManager();
-        $config->configureServiceManager($pm);
         $this->translator->setPluginManager($pm);
         $this->translator->addTranslationFile('test', null);
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

Laminas\ServiceManager\ConfigInterface is deprecated and removed in laminas/laminas-servicemanager v4.

Removing all uses except HelperConfig (which inherits so removal would be a breaking change) to make any future upgrade slightly easier.
