### PR TITLE
Remove dev dependency on laminas/laminas-cache-storage-deprecated-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
     "require-dev": {
         "laminas/laminas-cache": "^3.12.1",
         "laminas/laminas-cache-storage-adapter-memory": "^2.3.0",
-        "laminas/laminas-cache-storage-deprecated-factory": "^1.2",
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-config": "^3.9.0",
         "laminas/laminas-eventmanager": "^3.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1b44b8e5a020fa4e117b5e0af7e7c82",
+    "content-hash": "7ba779fabb243f44b4c5abf59ba06992",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -1158,65 +1158,6 @@
                 }
             ],
             "time": "2023-10-18T09:43:33+00:00"
-        },
-        {
-            "name": "laminas/laminas-cache-storage-deprecated-factory",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-cache-storage-deprecated-factory.git",
-                "reference": "276ffbb6c01400fb071d8f6167650e6112d2de2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-deprecated-factory/zipball/276ffbb6c01400fb071d8f6167650e6112d2de2f",
-                "reference": "276ffbb6c01400fb071d8f6167650e6112d2de2f",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-cache": "^3.0",
-                "laminas/laminas-servicemanager": "^3.7",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-                "webmozart/assert": "^1.10"
-            },
-            "require-dev": {
-                "laminas/laminas-cache-storage-adapter-apcu": "^2.4",
-                "laminas/laminas-cache-storage-adapter-blackhole": "^2.2",
-                "laminas/laminas-cache-storage-adapter-ext-mongodb": "^2.3",
-                "laminas/laminas-cache-storage-adapter-filesystem": "^2.3",
-                "laminas/laminas-cache-storage-adapter-memcached": "^2.4",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2",
-                "laminas/laminas-cache-storage-adapter-redis": "^2.5",
-                "laminas/laminas-cache-storage-adapter-session": "^2.3",
-                "laminas/laminas-coding-standard": "2.3",
-                "laminas/laminas-serializer": "^2.14",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Temporary storage adapter factory for fluent migration to laminas-cache v3 when working with laminas components which depend on laminas-cache",
-            "support": {
-                "issues": "https://github.com/laminas/laminas-cache-storage-deprecated-factory/issues",
-                "source": "https://github.com/laminas/laminas-cache-storage-deprecated-factory/tree/1.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-01-08T14:30:59+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -358,7 +358,6 @@
       <code><![CDATA[$file['type']]]></code>
       <code><![CDATA[$file['type']]]></code>
       <code><![CDATA[$loaderType]]></code>
-      <code><![CDATA[$options['cache']]]></code>
       <code><![CDATA[$pattern['base_dir']]]></code>
       <code><![CDATA[$pattern['pattern']]]></code>
       <code><![CDATA[$pattern['pattern']]]></code>

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -223,6 +223,10 @@ class Translator implements TranslatorInterface
             if ($options['cache'] instanceof CacheStorage) {
                 $translator->setCache($options['cache']);
             } else {
+                /**
+                 * @psalm-suppress UndefinedClass
+                 * @psalm-suppress MixedArgument
+                 */
                 $translator->setCache(Cache\StorageFactory::factory($options['cache']));
             }
         }

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\I18n\Translator;
 
+use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\Cache\Storage\StorageInterface;
-use Laminas\Cache\StorageFactory as CacheFactory;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
 use Laminas\I18n\Translator\TextDomain;
@@ -133,9 +133,7 @@ class TranslatorTest extends TestCase
                     'pattern'  => 'translation-%s.php',
                 ],
             ],
-            'cache'    => [
-                'adapter' => 'memory',
-            ],
+            'cache'    => new Memory(),
         ]);
 
         self::assertInstanceOf(Translator::class, $translator);
@@ -172,7 +170,7 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsLoadedFromCache(): void
     {
-        $cache = CacheFactory::factory(['adapter' => 'memory']);
+        $cache = new Memory();
         $this->translator->setCache($cache);
 
         $cache->addItem(
@@ -185,7 +183,7 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsAreStoredInCache(): void
     {
-        $cache = CacheFactory::factory(['adapter' => 'memory']);
+        $cache = new Memory();
         $this->translator->setCache($cache);
 
         $loader             = new TestLoader();
@@ -208,7 +206,7 @@ class TranslatorTest extends TestCase
         $textDomain = 'default';
         $locale     = 'en_EN';
 
-        $cache = CacheFactory::factory(['adapter' => 'memory']);
+        $cache = new Memory();
         $this->translator->setCache($cache);
 
         $cache->addItem(


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |/no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

laminas/laminas-cache-storage-deprecated-factory states "This factory will not provide support for laminas-cache v4+ and is only meant to be used as a temporary solution in combination with other laminas components."

Continued use is likely to make future maintenance of this package difficult

While it is used in one code path in Translator, as it is not a non-dev dependency I think it's safe to assume anyone using this functionality has it listed as one of their dependencies