### PR TITLE
Add support for laminas-filter v3 compatibility

### DIFF
--- a/src/Filter/AbstractLocale.php
+++ b/src/Filter/AbstractLocale.php
@@ -2,7 +2,7 @@
 
 namespace Laminas\I18n\Filter;
 
-use Laminas\Filter\AbstractFilter;
+use Laminas\Filter\FilterInterface;
 use Locale;
 
 /**
@@ -11,9 +11,9 @@ use Locale;
  *     ...
  * }
  * @template TOptions of Options
- * @extends AbstractFilter<TOptions>
+ * @implements AbstractFilter<TOptions>
  */
-abstract class AbstractLocale extends AbstractFilter
+abstract class AbstractLocale implements FilterInterface
 {
     public function __construct()
     {
@@ -42,5 +42,18 @@ abstract class AbstractLocale extends AbstractFilter
             $this->options['locale'] = Locale::getDefault();
         }
         return $this->options['locale'];
+    }
+
+     /**
+     * Defined by Laminas\Filter\FilterInterface
+     */
+    abstract public function filter(mixed $value): mixed;
+
+    /**
+     * Defined by Laminas\Filter\FilterInterface
+     */
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }


### PR DESCRIPTION
**(WORK IN PROGRESS)**
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description
**(WORK IN PROGRESS)**
In version 3 of `laminas-filter` , `Laminas\Filter\AbstractFilter` has been deprecated and removed. As AbstractLocale currently extends `AbstractFilter`, it must be refactored to directly implement `FilterInterface` to ensure future compatibility and align with Laminas-filter v3 architecture decisions.

Reference: https://docs.laminas.dev/laminas-filter/v2/migration/preparing-for-v3/#abstractfilter-removal

