### PR TITLE
Introduce a factory for the default country code list

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -54,7 +54,7 @@ class ConfigProvider
             'factories' => [
                 Translator\TranslatorInterface::class   => Translator\TranslatorServiceFactory::class,
                 Translator\LoaderPluginManager::class   => Translator\LoaderPluginManagerFactory::class,
-                Geography\DefaultCountryCodeList::class => Geography\DefaultCountryCodeList::create(...),
+                Geography\DefaultCountryCodeList::class => Geography\DefaultCountryCodeListFactory::class,
             ],
         ];
     }

--- a/src/Geography/DefaultCountryCodeListFactory.php
+++ b/src/Geography/DefaultCountryCodeListFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Geography;
+
+/**
+ * @internal
+ *
+ * @psalm-internal Laminas\I18n
+ * @psalm-internal LaminasTest\I18n
+ */
+final readonly class DefaultCountryCodeListFactory
+{
+    public function __invoke(): DefaultCountryCodeList
+    {
+        return DefaultCountryCodeList::create();
+    }
+}


### PR DESCRIPTION
#154 removed the array-style callable in favour of a 1st-class callable. The latter can't be cached, and Rector will continue to complain about usage of the array style callable unless there are awkward suppressions.

This patch remedies the situation by using a dedicated factory instead.

Fixes #162 