### PR TITLE
Swap out Laminas\Cache with Psr\Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,15 +35,15 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-ctype": "*",
         "ext-intl": "*",
-        "laminas/laminas-servicemanager": "^3.21.0",
+        "laminas/laminas-servicemanager": "^4.5.0",
         "laminas/laminas-stdlib": "^3.0",
         "laminas/laminas-translator": "^1.0",
-        "psr/container": "^1.0.0"
+        "psr/cache": "^2.0",
+        "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "laminas/laminas-cache": "^3.13.0",
-        "laminas/laminas-cache-storage-adapter-memory": "^2.4.0",
-        "laminas/laminas-cache-storage-deprecated-factory": "^1.3",
+        "laminas/laminas-cache": "^4.1.0",
+        "laminas/laminas-cache-storage-adapter-memory": "^3.1.0",
         "laminas/laminas-coding-standard": "^3.1",
         "laminas/laminas-config": "^3.10.1",
         "laminas/laminas-eventmanager": "^3.15.0",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "zendframework/zend-i18n": "*"
     },
     "suggest": {
-        "laminas/laminas-cache": "You should install this package to cache the translations",
+        "laminas/laminas-cache": "Provides a PSR-6 cache implementation for caching translations",
         "laminas/laminas-config": "You should install this package to use the INI translation format",
         "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
         "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,63 +4,109 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1d42fd003e54c9464971719c21fa869",
+    "content-hash": "e7f353dc4791f566702f0c7650f1d039",
     "packages": [
         {
-            "name": "laminas/laminas-servicemanager",
-            "version": "3.24.0",
+            "name": "brick/varexporter",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c"
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "af98bfc2b702a312abbcaff37656dbe419cec5bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b172a0df568bf37ebdfb3658263156eefe3c1e8c",
-                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/af98bfc2b702a312abbcaff37656dbe419cec5bc",
+                "reference": "af98bfc2b702a312abbcaff37656dbe419cec5bc",
                 "shasum": ""
             },
             "require": {
+                "nikic/php-parser": "^5.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "6.8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-20T17:42:39+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "a6996829c8ce55025cca1b57b1e8a8b165e3926c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a6996829c8ce55025cca1b57b1e8a8b165e3926c",
+                "reference": "a6996829c8ce55025cca1b57b1e8a8b165e3926c",
+                "shasum": ""
+            },
+            "require": {
+                "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0 || ^0.6.0",
                 "laminas/laminas-stdlib": "^3.19",
                 "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1 || ^2.0"
             },
             "conflict": {
-                "ext-psr": "*",
                 "laminas/laminas-code": "<4.10.0",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
+                "zendframework/zend-code": "<3.3.1"
             },
             "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
+                "psr/container-implementation": "^1.0 || ^2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "friendsofphp/proxy-manager-lts": "^1.0.18",
-                "laminas/laminas-code": "^4.16.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-container-config-test": "^1.1",
                 "mikey179/vfsstream": "^1.6.12",
                 "phpbench/phpbench": "^1.4.1",
                 "phpunit/phpunit": "^10.5.58",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.26.1"
+                "psalm/plugin-phpunit": "^0.19.5",
+                "symfony/console": "^6.4.17 || ^7.3.4",
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
-                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
+                "laminas/laminas-cli": "To consume CLI commands provided by this component"
             },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ServiceManager",
+                    "config-provider": "Laminas\\ServiceManager\\ConfigProvider"
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -82,11 +128,9 @@
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.5.0"
             },
             "funding": [
                 {
@@ -94,7 +138,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-10-14T09:03:51+00:00"
+            "time": "2025-10-14T09:41:04+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -207,6 +251,113 @@
                 }
             ],
             "time": "2025-10-14T20:58:42+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/2.0.0"
+            },
+            "time": "2021-02-03T23:23:37+00:00"
         },
         {
             "name": "psr/container",
@@ -1742,31 +1893,30 @@
         },
         {
             "name": "laminas/laminas-cache",
-            "version": "3.13.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "8225b16d03bbff2ecf2bd5a4f38c39ca47389e50"
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/8225b16d03bbff2ecf2bd5a4f38c39ca47389e50",
-                "reference": "8225b16d03bbff2ecf2bd5a4f38c39ca47389e50",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/557c34091fdee1791bc16ddc06af583f94caa2dd",
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-cache-storage-implementation": "1.0",
                 "laminas/laminas-eventmanager": "^3.4",
-                "laminas/laminas-servicemanager": "^3.21",
-                "laminas/laminas-stdlib": "^3.6",
+                "laminas/laminas-servicemanager": "^4.1",
+                "laminas/laminas-stdlib": "^3.20",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/cache": "^1.0",
+                "psr/cache": "^2.0 || ^3.0",
                 "psr/clock": "^1.0",
-                "psr/simple-cache": "^1.0",
-                "webmozart/assert": "^1.9"
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "webmozart/assert": "^1.11"
             },
             "conflict": {
-                "stella-maris/clock": "<0.1.7",
+                "laminas/laminas-serializer": "<3.0",
                 "symfony/console": "<5.1"
             },
             "provide": {
@@ -1774,20 +1924,13 @@
                 "psr/simple-cache-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-apcu": "^2.4",
-                "laminas/laminas-cache-storage-adapter-blackhole": "^2.3",
-                "laminas/laminas-cache-storage-adapter-filesystem": "^2.3",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2",
-                "laminas/laminas-cache-storage-adapter-test": "^2.4",
-                "laminas/laminas-cli": "^1.7",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-config-aggregator": "^1.13",
-                "laminas/laminas-feed": "^2.20",
-                "laminas/laminas-serializer": "^2.14",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.4"
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-config-aggregator": "^1.17",
+                "laminas/laminas-serializer": "^3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
@@ -1839,38 +1982,38 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-01-21T12:32:41+00:00"
+            "time": "2024-11-26T08:07:17+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
-            "version": "2.4.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
-                "reference": "12d2b191fee7ed0c08fd5db4441282705184f1bf"
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/12d2b191fee7ed0c08fd5db4441282705184f1bf",
-                "reference": "12d2b191fee7ed0c08fd5db4441282705184f1bf",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/10f0d64c0b3e381a8baaca108803111aa7b110db",
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-cache": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "laminas/laminas-servicemanager": "<3.11"
+                "laminas/laminas-cache": "^4.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
             },
             "provide": {
-                "laminas/laminas-cache-storage-implementation": "1.0"
+                "laminas/laminas-cache-storage-implementation": "2.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-benchmark": "^1.1.0",
-                "laminas/laminas-cache-storage-adapter-test": "^2.3.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^4.29.0"
+                "laminas/laminas-cache-storage-adapter-benchmark": "^2.0",
+                "laminas/laminas-cache-storage-adapter-test": "^4.1",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "lcobucci/clock": "^3.0",
+                "lctrs/psalm-psr-container-plugin": "^1.10",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.24"
             },
             "type": "library",
             "extra": {
@@ -1906,66 +2049,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-01-23T15:41:59+00:00"
-        },
-        {
-            "name": "laminas/laminas-cache-storage-deprecated-factory",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-cache-storage-deprecated-factory.git",
-                "reference": "f41c01e17a97105823d84525dd31e1c55d70ef06"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-deprecated-factory/zipball/f41c01e17a97105823d84525dd31e1c55d70ef06",
-                "reference": "f41c01e17a97105823d84525dd31e1c55d70ef06",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-cache": "^3.0",
-                "laminas/laminas-servicemanager": "^3.7",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "webmozart/assert": "^1.10"
-            },
-            "require-dev": {
-                "laminas/laminas-cache-storage-adapter-apcu": "^2.4",
-                "laminas/laminas-cache-storage-adapter-blackhole": "^2.2",
-                "laminas/laminas-cache-storage-adapter-ext-mongodb": "^2.3",
-                "laminas/laminas-cache-storage-adapter-filesystem": "^2.3",
-                "laminas/laminas-cache-storage-adapter-memcached": "^2.4",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2",
-                "laminas/laminas-cache-storage-adapter-redis": "^2.5",
-                "laminas/laminas-cache-storage-adapter-session": "^2.3",
-                "laminas/laminas-coding-standard": "2.3",
-                "laminas/laminas-serializer": "^2.14",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Temporary storage adapter factory for fluent migration to laminas-cache v3 when working with laminas components which depend on laminas-cache",
-            "support": {
-                "issues": "https://github.com/laminas/laminas-cache-storage-deprecated-factory/issues",
-                "source": "https://github.com/laminas/laminas-cache-storage-deprecated-factory/tree/1.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-01-07T14:23:29+00:00"
+            "time": "2024-11-27T08:14:09+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -2452,64 +2536,6 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.0"
             },
             "time": "2024-09-08T10:20:00+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
-            },
-            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3354,55 +3380,6 @@
             "time": "2025-03-31T18:49:55+00:00"
         },
         {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
-            },
-            "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3610,25 +3587,25 @@
         },
         {
             "name": "psr/simple-cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -3643,7 +3620,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for simple caching",
@@ -3655,9 +3632,9 @@
                 "simple-cache"
             ],
             "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
-            "time": "2017-10-23T01:57:42+00:00"
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "revolt/event-loop",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -123,11 +123,17 @@
     </MixedArrayAccess>
   </file>
   <file src="src/Translator/LoaderPluginManager.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[LoaderPluginManager]]></code>
+    </MethodSignatureMismatch>
     <MissingReturnType>
       <code><![CDATA[validatePlugin]]></code>
     </MissingReturnType>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$aliases]]></code>
+      <code><![CDATA[$factories]]></code>
+    </NonInvariantDocblockPropertyType>
     <ParamNameMismatch>
-      <code><![CDATA[$plugin]]></code>
       <code><![CDATA[$plugin]]></code>
     </ParamNameMismatch>
     <PossiblyUnusedMethod>
@@ -135,19 +141,12 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Translator/LoaderPluginManagerFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[LoaderPluginManagerFactory]]></code>
-    </DeprecatedInterface>
-    <DeprecatedProperty>
-      <code><![CDATA[$this->creationOptions]]></code>
-      <code><![CDATA[$this->creationOptions]]></code>
-    </DeprecatedProperty>
     <MixedArgument>
       <code><![CDATA[$config['translator_plugins']]]></code>
     </MixedArgument>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
+    <MoreSpecificImplementedParamType>
+      <code><![CDATA[$options]]></code>
+    </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Translator/Plural/Parser.php">
     <MixedArgument>
@@ -397,7 +396,6 @@
       <code><![CDATA[$pluginManager]]></code>
     </MissingConstructor>
     <MixedArgument>
-      <code><![CDATA[$cacheId]]></code>
       <code><![CDATA[$file['filename']]]></code>
       <code><![CDATA[$file['filename']]]></code>
       <code><![CDATA[$file['filename']]]></code>
@@ -406,7 +404,6 @@
       <code><![CDATA[$file['type']]]></code>
       <code><![CDATA[$file['type']]]></code>
       <code><![CDATA[$loaderType]]></code>
-      <code><![CDATA[$options['cache']]]></code>
       <code><![CDATA[$pattern['base_dir']]]></code>
       <code><![CDATA[$pattern['pattern']]]></code>
       <code><![CDATA[$pattern['pattern']]]></code>
@@ -480,9 +477,6 @@
     <PossiblyNullReference>
       <code><![CDATA[evaluate]]></code>
     </PossiblyNullReference>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$cacheId]]></code>
-    </PossiblyUndefinedVariable>
     <RedundantCondition>
       <code><![CDATA[$translation[$index] !== null]]></code>
       <code><![CDATA[isset($translation[$index]) && $translation[$index] !== '' && $translation[$index] !== null]]></code>
@@ -511,9 +505,6 @@
     </DeprecatedInterface>
   </file>
   <file src="src/Translator/TranslatorServiceFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[TranslatorServiceFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$container->get('TranslatorPluginManager')]]></code>
       <code><![CDATA[$trConfig]]></code>

--- a/src/Translator/LoaderPluginManager.php
+++ b/src/Translator/LoaderPluginManager.php
@@ -59,7 +59,7 @@ use function sprintf;
 class LoaderPluginManager extends AbstractPluginManager
 {
     /** @inheritDoc */
-    protected $aliases = [
+    protected array $aliases = [
         'gettext'  => Loader\Gettext::class,
         'getText'  => Loader\Gettext::class,
         'GetText'  => Loader\Gettext::class,
@@ -80,7 +80,7 @@ class LoaderPluginManager extends AbstractPluginManager
     ];
 
     /** @inheritDoc */
-    protected $factories = [
+    protected array $factories = [
         Loader\Gettext::class  => InvokableFactory::class,
         Loader\Ini::class      => InvokableFactory::class,
         Loader\PhpArray::class => InvokableFactory::class,
@@ -98,12 +98,10 @@ class LoaderPluginManager extends AbstractPluginManager
      * Checks that the filter loaded is an instance of
      * Loader\FileLoaderInterface or Loader\RemoteLoaderInterface.
      *
-     * @param  mixed $plugin
-     * @return void
      * @throws Exception\RuntimeException If invalid.
      * @psalm-assert InstanceType $plugin
      */
-    public function validate($plugin)
+    public function validate(mixed $plugin): void
     {
         if ($plugin instanceof FileLoaderInterface || $plugin instanceof RemoteLoaderInterface) {
             // we're okay

--- a/src/Translator/LoaderPluginManagerFactory.php
+++ b/src/Translator/LoaderPluginManagerFactory.php
@@ -2,39 +2,26 @@
 
 namespace Laminas\I18n\Translator;
 
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
 
 use function is_array;
 
-/**
- * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @final
- */
-class LoaderPluginManagerFactory implements FactoryInterface
+/** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
+final readonly class LoaderPluginManagerFactory implements FactoryInterface
 {
-    /**
-     * laminas-servicemanager v2 options passed to factory.
-     *
-     * @deprecated Since 2.16.0 - This component is no longer compatible with Service Manager v2.
-     *             This property will be removed in version 3.0
-     *
-     * @var array
-     */
-    protected $creationOptions = [];
-
     /**
      * Create and return a LoaderPluginManager.
      *
-     * @param string $name
      * @param array<string, mixed>|null $options
      * @psalm-param ServiceManagerConfiguration|null $options
-     * @return LoaderPluginManager
      */
-    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null,
+    ): LoaderPluginManager {
         $options     ??= [];
         $pluginManager = new LoaderPluginManager($container, $options);
 
@@ -60,31 +47,5 @@ class LoaderPluginManagerFactory implements FactoryInterface
         $pluginManager->configure($config['translator_plugins']);
 
         return $pluginManager;
-    }
-
-    /**
-     * laminas-servicemanager v2 factory to return LoaderPluginManager
-     *
-     * @deprecated Since 2.16.0 - This component is no longer compatible with Service Manager v2.
-     *             This method will be removed in version 3.0
-     *
-     * @return LoaderPluginManager
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, 'TranslatorPluginManager', $this->creationOptions);
-    }
-
-    /**
-     * v2 support for instance creation options.
-     *
-     * @deprecated Since 2.16.0 - This component is no longer compatible with Service Manager v2.
-     *             This method will be removed in version 3.0
-     *
-     * @return void
-     */
-    public function setCreationOptions(array $options)
-    {
-        $this->creationOptions = $options;
     }
 }

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -2,8 +2,6 @@
 
 namespace Laminas\I18n\Translator;
 
-use Laminas\Cache;
-use Laminas\Cache\Storage\StorageInterface as CacheStorage;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
@@ -13,6 +11,7 @@ use Laminas\I18n\Translator\Loader\RemoteLoaderInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Locale;
+use Psr\Cache\CacheItemPoolInterface;
 use Traversable;
 
 use function array_shift;
@@ -83,12 +82,7 @@ class Translator implements TranslatorInterface
      */
     protected $fallbackLocale;
 
-    /**
-     * Translation cache.
-     *
-     * @var CacheStorage|null
-     */
-    protected $cache;
+    private CacheItemPoolInterface|null $cache = null;
 
     /**
      * Plugin manager for translation loaders.
@@ -222,10 +216,8 @@ class Translator implements TranslatorInterface
 
         // cache
         if (isset($options['cache'])) {
-            if ($options['cache'] instanceof CacheStorage) {
+            if ($options['cache'] instanceof CacheItemPoolInterface) {
                 $translator->setCache($options['cache']);
-            } else {
-                $translator->setCache(Cache\StorageFactory::factory($options['cache']));
             }
         }
 
@@ -287,24 +279,14 @@ class Translator implements TranslatorInterface
         return $this->fallbackLocale;
     }
 
-    /**
-     * Sets a cache
-     *
-     * @return $this
-     */
-    public function setCache(?CacheStorage $cache = null)
+    public function setCache(CacheItemPoolInterface|null $cache = null): self
     {
         $this->cache = $cache;
 
         return $this;
     }
 
-    /**
-     * Returns the set cache
-     *
-     * @return CacheStorage|null The set cache
-     */
-    public function getCache()
+    public function getCache(): CacheItemPoolInterface|null
     {
         return $this->cache;
     }
@@ -569,39 +551,33 @@ class Translator implements TranslatorInterface
 
     /**
      * Clears the cache for a specific textDomain and locale.
-     *
-     * @param  string $textDomain
-     * @param  string $locale
-     * @return bool
      */
-    public function clearCache($textDomain, $locale)
+    public function clearCache(string $textDomain, string $locale): bool
     {
-        if (null === ($cache = $this->getCache())) {
+        if ($this->cache === null) {
             return false;
         }
-        return $cache->removeItem($this->getCacheId($textDomain, $locale));
+
+        return $this->cache->deleteItem($this->getCacheId($textDomain, $locale));
     }
 
     /**
      * Load messages for a given language and domain.
      *
      * @triggers loadMessages.no-messages-loaded
-     * @param    string $textDomain
-     * @param    string $locale
-     * @throws   Exception\RuntimeException
-     * @return   void
+     * @throws Exception\RuntimeException
      */
-    protected function loadMessages($textDomain, $locale)
+    protected function loadMessages(string $textDomain, string $locale): void
     {
         if (! isset($this->messages[$textDomain])) {
             $this->messages[$textDomain] = [];
         }
 
-        if (null !== ($cache = $this->getCache())) {
+        if ($this->cache !== null) {
             $cacheId = $this->getCacheId($textDomain, $locale);
-
-            if (null !== ($result = $cache->getItem($cacheId))) {
-                $this->messages[$textDomain][$locale] = $result;
+            $item    = $this->cache->getItem($cacheId);
+            if ($item->isHit()) {
+                $this->messages[$textDomain][$locale] = $item->get();
 
                 return;
             }
@@ -633,8 +609,11 @@ class Translator implements TranslatorInterface
             $this->messages[$textDomain][$locale] = $discoveredTextDomain;
         }
 
-        if ($cache !== null) {
-            $cache->setItem($cacheId, $this->messages[$textDomain][$locale]);
+        if ($this->cache !== null) {
+            $cacheId = $this->getCacheId($textDomain, $locale);
+            $item    = $this->cache->getItem($cacheId);
+            $item->set($this->messages[$textDomain][$locale]);
+            $this->cache->save($item);
         }
     }
 

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -1,27 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\I18n\Translator;
 
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 
-/**
- * Translator.
- *
- * @final
- */
-class TranslatorServiceFactory implements FactoryInterface
+final readonly class TranslatorServiceFactory implements FactoryInterface
 {
-    /**
-     * Create a Translator instance.
-     *
-     * @param string $requestedName
-     * @param null|array $options
-     * @return Translator
-     */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null,
+    ): Translator {
         // Configure the translator
         $config     = $container->get('config');
         $trConfig   = $config['translator'] ?? [];
@@ -30,20 +22,5 @@ class TranslatorServiceFactory implements FactoryInterface
             $translator->setPluginManager($container->get('TranslatorPluginManager'));
         }
         return $translator;
-    }
-
-    /**
-     * laminas-servicemanager v2 factory for creating Translator instance.
-     *
-     * @deprecated Since 2.16.0 - This component is no longer compatible with Service Manager v2.
-     *             This method will be removed in version 3.0
-     *
-     * Proxies to `__invoke()`.
-     *
-     * @return Translator
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, Translator::class);
     }
 }

--- a/test/Translator/LoaderPluginManagerFactoryTest.php
+++ b/test/Translator/LoaderPluginManagerFactoryTest.php
@@ -8,7 +8,6 @@ use Laminas\I18n\Translator\Loader\FileLoaderInterface;
 use Laminas\I18n\Translator\Loader\PhpArray;
 use Laminas\I18n\Translator\LoaderPluginManager;
 use Laminas\I18n\Translator\LoaderPluginManagerFactory;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use LaminasTest\I18n\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Container\ContainerInterface;
@@ -21,15 +20,6 @@ final class LoaderPluginManagerFactoryTest extends TestCase
 
         $factory = new LoaderPluginManagerFactory();
         $loaders = $factory($container, 'TranslatorPluginManager');
-        self::assertInstanceOf(LoaderPluginManager::class, $loaders);
-        self::assertFalse($loaders->has('test'));
-    }
-
-    public function testCreateServiceReturnsUnConfiguredPluginManagerWhenNoOptionsPresent(): void
-    {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-        $factory   = new LoaderPluginManagerFactory();
-        $loaders   = $factory->createService($container);
         self::assertInstanceOf(LoaderPluginManager::class, $loaders);
         self::assertFalse($loaders->has('test'));
     }
@@ -58,22 +48,6 @@ final class LoaderPluginManagerFactoryTest extends TestCase
                 'test' => $loader,
             ],
         ]);
-        self::assertInstanceOf(LoaderPluginManager::class, $loaders);
-        self::assertTrue($loaders->has('test'));
-    }
-
-    #[DataProvider('provideLoader')]
-    public function testCreateServiceCanConfigurePluginManagerViaOptions(string $loader): void
-    {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-
-        $factory = new LoaderPluginManagerFactory();
-        $factory->setCreationOptions([
-            'aliases' => [
-                'test' => $loader,
-            ],
-        ]);
-        $loaders = $factory->createService($container);
         self::assertInstanceOf(LoaderPluginManager::class, $loaders);
         self::assertTrue($loaders->has('test'));
     }

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\I18n\Translator;
 
-use Laminas\Cache\Storage\StorageInterface;
-use Laminas\Cache\StorageFactory as CacheFactory;
+use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
+use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
 use Laminas\I18n\Translator\TextDomain;
@@ -123,6 +123,8 @@ final class TranslatorTest extends TestCase
 
     public function testFactoryCreatesTranslatorWithCache(): void
     {
+        $cacheItemPool = new CacheItemPoolDecorator(new Memory());
+
         $translator = Translator::factory([
             'locale'   => 'de_DE',
             'patterns' => [
@@ -132,13 +134,11 @@ final class TranslatorTest extends TestCase
                     'pattern'  => 'translation-%s.php',
                 ],
             ],
-            'cache'    => [
-                'adapter' => 'memory',
-            ],
+            'cache'    => $cacheItemPool,
         ]);
 
         self::assertInstanceOf(Translator::class, $translator);
-        self::assertInstanceOf(StorageInterface::class, $translator->getCache());
+        self::assertSame($cacheItemPool, $translator->getCache());
     }
 
     public function testDefaultLocale(): void
@@ -170,20 +170,19 @@ final class TranslatorTest extends TestCase
 
     public function testTranslationsLoadedFromCache(): void
     {
-        $cache = CacheFactory::factory(['adapter' => 'memory']);
+        $cache = new CacheItemPoolDecorator(new Memory());
         $this->translator->setCache($cache);
 
-        $cache->addItem(
-            $this->translator->getCacheId('default', 'en_EN'),
-            new TextDomain(['foo' => 'bar'])
-        );
+        $item = $cache->getItem($this->translator->getCacheId('default', 'en_EN'));
+        $item->set(new TextDomain(['foo' => 'bar']));
+        $cache->save($item);
 
         self::assertEquals('bar', $this->translator->translate('foo'));
     }
 
     public function testTranslationsAreStoredInCache(): void
     {
-        $cache = CacheFactory::factory(['adapter' => 'memory']);
+        $cache = new CacheItemPoolDecorator(new Memory());
         $this->translator->setCache($cache);
 
         $loader             = new TestLoader();
@@ -195,9 +194,10 @@ final class TranslatorTest extends TestCase
 
         self::assertEquals('bar', $this->translator->translate('foo'));
 
-        $item = $cache->getItem($this->translator->getCacheId('default', 'en_EN'));
-        self::assertInstanceOf(TextDomain::class, $item);
-        self::assertEquals('bar', $item['foo']);
+        $item   = $cache->getItem($this->translator->getCacheId('default', 'en_EN'));
+        $result = $item->get();
+        self::assertInstanceOf(TextDomain::class, $result);
+        self::assertEquals('bar', $result['foo']);
     }
 
     public function testTranslationsAreClearedFromCache(): void
@@ -205,19 +205,17 @@ final class TranslatorTest extends TestCase
         $textDomain = 'default';
         $locale     = 'en_EN';
 
-        $cache = CacheFactory::factory(['adapter' => 'memory']);
+        $cache = new CacheItemPoolDecorator(new Memory());
         $this->translator->setCache($cache);
 
-        $cache->addItem(
-            $this->translator->getCacheId($textDomain, $locale),
-            new TextDomain(['foo' => 'bar'])
-        );
+        $item = $cache->getItem($this->translator->getCacheId($textDomain, $locale));
+        $item->set(new TextDomain(['foo' => 'bar']));
+        $cache->save($item);
 
         self::assertTrue($this->translator->clearCache($textDomain, $locale));
 
-        $item = $cache->getItem($this->translator->getCacheId($textDomain, $locale), $success);
-        self::assertNull($item);
-        self::assertFalse($success);
+        $item = $cache->getItem($this->translator->getCacheId($textDomain, $locale));
+        self::assertFalse($item->isHit());
     }
 
     public function testClearCacheReturnsFalseIfNoCacheIsPresent(): void

--- a/tools/crc/config.json
+++ b/tools/crc/config.json
@@ -1,7 +1,5 @@
 {
     "symbol-whitelist" : [
-        "Laminas\\Cache\\StorageFactory",
-        "Laminas\\Cache\\Storage\\StorageInterface",
         "Laminas\\Config\\Reader\\Ini",
         "Laminas\\EventManager\\Event",
         "Laminas\\EventManager\\EventManager",


### PR DESCRIPTION
Changes the translator to use a PSR-6 cache so that we can de-couple dependencies somewhat…

Does the bare minimum of compat work with Service Manager v4.

The translator itself still needs a big refactor…