### PR TITLE
First Pass at Refactoring the Concrete Translator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-ctype": "*",
         "ext-intl": "*",
+        "laminas/laminas-eventmanager": "^3.15.0",
         "laminas/laminas-servicemanager": "^4.5.0",
         "laminas/laminas-stdlib": "^3.0",
         "laminas/laminas-translator": "^1.0",
@@ -45,7 +46,6 @@
         "laminas/laminas-cache": "^4.1.0",
         "laminas/laminas-cache-storage-adapter-memory": "^3.1.0",
         "laminas/laminas-coding-standard": "^3.1",
-        "laminas/laminas-eventmanager": "^3.15.0",
         "phpunit/phpunit": "^11.5.46",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.14.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61a1909ee0888e51cf9ebbe4e395c61a",
+    "content-hash": "6f53fd5013f73b2cc054a6f11ed560e0",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -54,6 +54,77 @@
                 }
             ],
             "time": "2025-02-20T17:42:39+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/90b4bd33264629af8e39caf5aa83473ac03aa04c",
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2",
+                "zendframework/zend-eventmanager": "*"
+            },
+            "require-dev": {
+                "amphp/dns": "^2.2",
+                "amphp/socket": "^2.3.1",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-stdlib": "^3.20",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/container": "^1.1.2 || ^2.0.2",
+                "sebastian/recursion-context": "^5.0.1",
+                "vimeo/psalm": "^6.13"
+            },
+            "suggest": {
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-31T10:29:01+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -2108,77 +2179,6 @@
                 }
             ],
             "time": "2025-05-13T08:37:04+00:00"
-        },
-        {
-            "name": "laminas/laminas-eventmanager",
-            "version": "3.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/90b4bd33264629af8e39caf5aa83473ac03aa04c",
-                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
-            },
-            "conflict": {
-                "container-interop/container-interop": "<1.2",
-                "zendframework/zend-eventmanager": "*"
-            },
-            "require-dev": {
-                "amphp/dns": "^2.2",
-                "amphp/socket": "^2.3.1",
-                "laminas/laminas-coding-standard": "~3.1.0",
-                "laminas/laminas-stdlib": "^3.20",
-                "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.58",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "psr/container": "^1.1.2 || ^2.0.2",
-                "sebastian/recursion-context": "^5.0.1",
-                "vimeo/psalm": "^6.13"
-            },
-            "suggest": {
-                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
-                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\EventManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Trigger and listen to events within a PHP application",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "event",
-                "eventmanager",
-                "events",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
-                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-eventmanager"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-10-31T10:29:01+00:00"
         },
         {
             "name": "league/uri",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -126,10 +126,6 @@
       <code><![CDATA[$r]]></code>
       <code><![CDATA[$r]]></code>
     </MissingClosureParamType>
-    <MissingConstructor>
-      <code><![CDATA[$events]]></code>
-      <code><![CDATA[$pluginManager]]></code>
-    </MissingConstructor>
     <MixedArgument>
       <code><![CDATA[$file['filename']]]></code>
       <code><![CDATA[$file['filename']]]></code>
@@ -219,7 +215,6 @@
   </file>
   <file src="src/Translator/TranslatorServiceFactory.php">
     <MixedArgument>
-      <code><![CDATA[$container->get('TranslatorPluginManager')]]></code>
       <code><![CDATA[$trConfig]]></code>
     </MixedArgument>
     <MixedArrayAccess>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -208,9 +208,6 @@
     <PossiblyNullReference>
       <code><![CDATA[evaluate]]></code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$events]]></code>
-    </PropertyNotSetInConstructor>
     <RedundantCondition>
       <code><![CDATA[$translation[$index] !== null]]></code>
       <code><![CDATA[isset($translation[$index]) && $translation[$index] !== '' && $translation[$index] !== null]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -208,6 +208,9 @@
     <PossiblyNullReference>
       <code><![CDATA[evaluate]]></code>
     </PossiblyNullReference>
+    <PropertyNotSetInConstructor>
+      <code><![CDATA[$events]]></code>
+    </PropertyNotSetInConstructor>
     <RedundantCondition>
       <code><![CDATA[$translation[$index] !== null]]></code>
       <code><![CDATA[isset($translation[$index]) && $translation[$index] !== '' && $translation[$index] !== null]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,12 +5,10 @@
       <code><![CDATA[ExtensionNotLoadedException]]></code>
     </UnusedClass>
   </file>
-  <file src="src/Translator/Loader/AbstractFileLoader.php">
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $flag]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="src/Translator/Loader/Gettext.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$textDomain]]></code>
+    </ArgumentTypeCoercion>
     <FalsableReturnStatement>
       <code><![CDATA[unpack('N' . $num, fread($this->file, 4 * $num))]]></code>
       <code><![CDATA[unpack('V' . $num, fread($this->file, 4 * $num))]]></code>
@@ -70,27 +68,21 @@
       <code><![CDATA[$content]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
+  <file src="src/Translator/Loader/Ini.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$messages]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="src/Translator/Loader/PhpArray.php">
-    <MixedArgument>
-      <code><![CDATA[$textDomain['']['plural_forms']]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$textDomain['']['plural_forms']]]></code>
-    </MixedArrayAccess>
-    <UnresolvableInclude>
-      <code><![CDATA[include $fromIncludePath]]></code>
-    </UnresolvableInclude>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$messages]]></code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Translator/Loader/PhpMemoryArray.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($this->messages)]]></code>
-    </DocblockTypeContradiction>
-    <MixedArgument>
-      <code><![CDATA[$textDomain['']['plural_forms']]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$messages]]></code>
+    </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code><![CDATA[$textDomain['']['plural_forms']]]></code>
       <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
     </MixedArrayAccess>
   </file>
@@ -107,111 +99,38 @@
       <code><![CDATA[$options]]></code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="src/Translator/TextDomain.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$textDomain->getPluralRule()]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference>
-      <code><![CDATA[getNumPlurals]]></code>
-      <code><![CDATA[getNumPlurals]]></code>
-    </PossiblyNullReference>
-  </file>
   <file src="src/Translator/Translator.php">
     <DocblockTypeContradiction>
-      <code><![CDATA[$message === null]]></code>
-      <code><![CDATA[$message === null]]></code>
       <code><![CDATA[is_array($options)]]></code>
     </DocblockTypeContradiction>
-    <MissingClosureParamType>
-      <code><![CDATA[$r]]></code>
-      <code><![CDATA[$r]]></code>
-    </MissingClosureParamType>
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[string|null]]></code>
+    </ImplementedReturnTypeMismatch>
     <MixedArgument>
-      <code><![CDATA[$file['filename']]]></code>
-      <code><![CDATA[$file['filename']]]></code>
-      <code><![CDATA[$file['filename']]]></code>
-      <code><![CDATA[$file['locale'] ?? null]]></code>
-      <code><![CDATA[$file['text_domain'] ?? 'default']]></code>
-      <code><![CDATA[$file['type']]]></code>
-      <code><![CDATA[$file['type']]]></code>
-      <code><![CDATA[$loaderType]]></code>
-      <code><![CDATA[$pattern['base_dir']]]></code>
-      <code><![CDATA[$pattern['pattern']]]></code>
-      <code><![CDATA[$pattern['pattern']]]></code>
-      <code><![CDATA[$pattern['text_domain'] ?? 'default']]></code>
-      <code><![CDATA[$pattern['type']]]></code>
-      <code><![CDATA[$pattern['type']]]></code>
-      <code><![CDATA[$remote['text_domain'] ?? 'default']]></code>
+      <code><![CDATA[$remote['text_domain'] ?? self::DEFAULT_TEXT_DOMAIN]]></code>
       <code><![CDATA[$remote['type']]]></code>
       <code><![CDATA[array_shift($locales)]]></code>
       <code><![CDATA[array_shift($locales)]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code><![CDATA[$file['filename']]]></code>
-      <code><![CDATA[$file['filename']]]></code>
-      <code><![CDATA[$file['filename']]]></code>
-      <code><![CDATA[$file['locale']]]></code>
-      <code><![CDATA[$file['text_domain']]]></code>
-      <code><![CDATA[$file['type']]]></code>
-      <code><![CDATA[$file['type']]]></code>
-      <code><![CDATA[$pattern['baseDir']]]></code>
-      <code><![CDATA[$pattern['base_dir']]]></code>
-      <code><![CDATA[$pattern['pattern']]]></code>
-      <code><![CDATA[$pattern['pattern']]]></code>
-      <code><![CDATA[$pattern['text_domain']]]></code>
-      <code><![CDATA[$pattern['type']]]></code>
-      <code><![CDATA[$pattern['type']]]></code>
       <code><![CDATA[$remote['text_domain']]]></code>
       <code><![CDATA[$remote['type']]]></code>
-      <code><![CDATA[$this->files[$textDomain][$currentLocale]]]></code>
-      <code><![CDATA[$this->files[$textDomain][$currentLocale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale][$message]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale][$textDomain . "\x04" . $message]]]></code>
     </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->files[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale]]]></code>
-      <code><![CDATA[$this->patterns[$textDomain][]]]></code>
-      <code><![CDATA[$this->remote[$textDomain][]]]></code>
-    </MixedArrayAssignment>
     <MixedAssignment>
-      <code><![CDATA[$file]]></code>
-      <code><![CDATA[$file]]></code>
       <code><![CDATA[$last]]></code>
       <code><![CDATA[$last]]></code>
-      <code><![CDATA[$loaderType]]></code>
-      <code><![CDATA[$pattern]]></code>
-      <code><![CDATA[$pattern]]></code>
       <code><![CDATA[$remote]]></code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[merge]]></code>
-      <code><![CDATA[merge]]></code>
-      <code><![CDATA[merge]]></code>
-    </MixedMethodCall>
-    <MixedOperand>
-      <code><![CDATA[$pattern['baseDir']]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->messages[$textDomain][$locale][$message]]]></code>
-      <code><![CDATA[$this->messages[$textDomain][$locale][$textDomain . "\x04" . $message]]]></code>
-    </MixedReturnStatement>
-    <PossiblyNullReference>
-      <code><![CDATA[evaluate]]></code>
-    </PossiblyNullReference>
-    <RedundantCondition>
+    <PossiblyNullArgument>
+      <code><![CDATA[array_shift($locales)]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[getFallbackLocale]]></code>
+    </PossiblyUnusedMethod>
+    <RedundantConditionGivenDocblockType>
       <code><![CDATA[$translation[$index] !== null]]></code>
       <code><![CDATA[isset($translation[$index]) && $translation[$index] !== '' && $translation[$index] !== null]]></code>
-    </RedundantCondition>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Translator/TranslatorServiceFactory.php">
     <MixedArgument>
@@ -230,37 +149,12 @@
       <code><![CDATA[assertNotNull]]></code>
     </RedundantCondition>
   </file>
-  <file src="test/Translator/Loader/GettextTest.php">
-    <PossiblyNullReference>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-    </PossiblyNullReference>
-  </file>
-  <file src="test/Translator/Loader/PhpArrayTest.php">
-    <PossiblyNullReference>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-    </PossiblyNullReference>
-  </file>
   <file src="test/Translator/Loader/PhpMemoryArrayTest.php">
-    <InvalidArgument>
-      <code><![CDATA['foo']]></code>
-    </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[include $this->testFilesDir . '/translation_empty.php']]></code>
       <code><![CDATA[include $this->testFilesDir . '/translation_en.php']]></code>
       <code><![CDATA[include $this->testFilesDir . '/translation_en.php']]></code>
     </MixedArgument>
-    <PossiblyNullReference>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-    </PossiblyNullReference>
     <UnresolvableInclude>
       <code><![CDATA[include $this->testFilesDir . '/translation_empty.php']]></code>
       <code><![CDATA[include $this->testFilesDir . '/translation_en.php']]></code>
@@ -271,30 +165,5 @@
     <UnusedClosureParam>
       <code><![CDATA[$container]]></code>
     </UnusedClosureParam>
-  </file>
-  <file src="test/Translator/TestAsset/Loader.php">
-    <ParamNameMismatch>
-      <code><![CDATA[$filename]]></code>
-      <code><![CDATA[$locale]]></code>
-    </ParamNameMismatch>
-  </file>
-  <file src="test/Translator/TextDomainTest.php">
-    <PossiblyNullReference>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[evaluate]]></code>
-      <code><![CDATA[getNumPlurals]]></code>
-      <code><![CDATA[getNumPlurals]]></code>
-      <code><![CDATA[getNumPlurals]]></code>
-    </PossiblyNullReference>
-  </file>
-  <file src="test/Translator/TranslatorTest.php">
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
   </file>
 </files>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -43,9 +43,10 @@ final class ConfigProvider
     {
         return [
             'aliases'   => [
-                'TranslatorPluginManager'                 => Translator\LoaderPluginManager::class,
-                Geography\CountryCodeListInterface::class => Geography\DefaultCountryCodeList::class,
-                TranslatorInterface::class                => Translator\Translator::class,
+                'TranslatorPluginManager'                      => Translator\LoaderPluginManager::class,
+                Translator\LoaderPluginManagerInterface::class => Translator\LoaderPluginManager::class,
+                Geography\CountryCodeListInterface::class      => Geography\DefaultCountryCodeList::class,
+                TranslatorInterface::class                     => Translator\Translator::class,
             ],
             'factories' => [
                 Translator\Translator::class            => Translator\TranslatorServiceFactory::class,

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -43,10 +43,10 @@ final class ConfigProvider
     {
         return [
             'aliases'   => [
-                'TranslatorPluginManager'                      => Translator\LoaderPluginManager::class,
-                Translator\LoaderPluginManagerInterface::class => Translator\LoaderPluginManager::class,
-                Geography\CountryCodeListInterface::class      => Geography\DefaultCountryCodeList::class,
-                TranslatorInterface::class                     => Translator\Translator::class,
+                'TranslatorPluginManager'                             => Translator\LoaderPluginManager::class,
+                Translator\MessageLoaderPluginManagerInterface::class => Translator\LoaderPluginManager::class,
+                Geography\CountryCodeListInterface::class             => Geography\DefaultCountryCodeList::class,
+                TranslatorInterface::class                            => Translator\Translator::class,
             ],
             'factories' => [
                 Translator\Translator::class            => Translator\TranslatorServiceFactory::class,

--- a/src/Translator/Loader/AbstractFileLoader.php
+++ b/src/Translator/Loader/AbstractFileLoader.php
@@ -16,29 +16,24 @@ abstract class AbstractFileLoader implements FileLoaderInterface
 {
     /**
      * Whether or not to consult the include_path when locating files
-     *
-     * @var bool
      */
-    protected $useIncludePath = false;
+    private bool $useIncludePath = false;
 
     /**
      * Indicate whether or not to use the include_path to resolve translation files
      *
-     * @param bool $flag
-     * @return self
+     * @return $this
      */
-    public function setUseIncludePath($flag = true)
+    public function setUseIncludePath(bool $flag = true): static
     {
-        $this->useIncludePath = (bool) $flag;
+        $this->useIncludePath = $flag;
         return $this;
     }
 
     /**
      * Are we using the include_path to resolve translation files?
-     *
-     * @return bool
      */
-    public function useIncludePath()
+    public function useIncludePath(): bool
     {
         return $this->useIncludePath;
     }
@@ -50,10 +45,10 @@ abstract class AbstractFileLoader implements FileLoaderInterface
      * flag is enabled, it will attempt to resolve the file from the
      * include_path if the file does not exist on the current working path.
      *
-     * @param string $filename
-     * @return string|false
+     * @param non-empty-string $filename
+     * @return non-empty-string|false
      */
-    protected function resolveFile($filename)
+    protected function resolveFile(string $filename): string|false
     {
         if (! is_file($filename) || ! is_readable($filename)) {
             if (! $this->useIncludePath()) {
@@ -67,15 +62,24 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     /**
      * Resolve a translation file via the include_path
      *
-     * @param string $filename
-     * @return string|false
+     * @param non-empty-string $filename
+     * @return non-empty-string|false
      */
-    protected function resolveViaIncludePath($filename)
+    protected function resolveViaIncludePath(string $filename): string|false
     {
         $resolvedIncludePath = stream_resolve_include_path($filename);
-        if ($resolvedIncludePath === false || ! is_file($resolvedIncludePath) || ! is_readable($resolvedIncludePath)) {
+        if (
+            $resolvedIncludePath === false
+            ||
+            ! is_file($resolvedIncludePath)
+            ||
+            ! is_readable($resolvedIncludePath)
+            ||
+            $resolvedIncludePath === ''
+        ) {
             return false;
         }
+
         return $resolvedIncludePath;
     }
 }

--- a/src/Translator/Loader/FileLoaderInterface.php
+++ b/src/Translator/Loader/FileLoaderInterface.php
@@ -14,9 +14,8 @@ interface FileLoaderInterface
     /**
      * Load translations from a file.
      *
-     * @param  string $locale
-     * @param  string $filename
-     * @return TextDomain|null
+     * @param non-empty-string $locale
+     * @param non-empty-string $filename
      */
-    public function load($locale, $filename);
+    public function load(string $locale, string $filename): TextDomain|null;
 }

--- a/src/Translator/Loader/Gettext.php
+++ b/src/Translator/Loader/Gettext.php
@@ -15,6 +15,7 @@ use function fclose;
 use function fopen;
 use function fread;
 use function fseek;
+use function is_string;
 use function sprintf;
 use function strtolower;
 use function trim;
@@ -42,16 +43,9 @@ class Gettext extends AbstractFileLoader
     protected $littleEndian;
 
     /**
-     * load(): defined by FileLoaderInterface.
-     *
-     * @see    FileLoaderInterface::load()
-     *
-     * @param  string $locale
-     * @param  string $filename
-     * @return TextDomain
      * @throws Exception\InvalidArgumentException
      */
-    public function load($locale, $filename)
+    public function load(string $locale, string $filename): TextDomain|null
     {
         $resolvedFile = $this->resolveFile($filename);
         if ($resolvedFile === false) {
@@ -61,7 +55,7 @@ class Gettext extends AbstractFileLoader
             ));
         }
 
-        $textDomain = new TextDomain();
+        $textDomain = [];
 
         ErrorHandler::start();
         $this->file = fopen($resolvedFile, 'rb');
@@ -147,22 +141,27 @@ class Gettext extends AbstractFileLoader
             }
         }
 
+        fclose($this->file);
+
+        $pluralRule = null;
         // Read header entries
-        if ($textDomain->offsetExists('')) {
-            $rawHeaders = explode("\n", trim((string) $textDomain['']));
+        if (isset($textDomain['']) && is_string($textDomain[''])) {
+            $rawHeaders = explode("\n", trim($textDomain['']));
 
             foreach ($rawHeaders as $rawHeader) {
                 [$header, $content] = explode(':', $rawHeader, 2);
-
                 if (strtolower(trim($header)) === 'plural-forms') {
-                    $textDomain->setPluralRule(PluralRule::fromString($content));
+                    $pluralRule = $content;
                 }
             }
 
             unset($textDomain['']);
         }
 
-        fclose($this->file);
+        $textDomain = new TextDomain($textDomain);
+        if (is_string($pluralRule) && $pluralRule !== '') {
+            $textDomain->setPluralRule(PluralRule::fromString($pluralRule));
+        }
 
         return $textDomain;
     }

--- a/src/Translator/Loader/Ini.php
+++ b/src/Translator/Loader/Ini.php
@@ -22,8 +22,7 @@ use function stream_resolve_include_path;
  */
 final class Ini implements FileLoaderInterface
 {
-    /** @inheritDoc */
-    public function load($locale, $filename): TextDomain
+    public function load(string $locale, string $filename): TextDomain|null
     {
         $resolvedIncludePath = stream_resolve_include_path($filename);
         $fromIncludePath     = $resolvedIncludePath !== false ? $resolvedIncludePath : $filename;

--- a/src/Translator/Loader/PhpArray.php
+++ b/src/Translator/Loader/PhpArray.php
@@ -12,6 +12,7 @@ use function gettype;
 use function is_array;
 use function is_file;
 use function is_readable;
+use function is_string;
 use function sprintf;
 use function stream_resolve_include_path;
 
@@ -23,16 +24,9 @@ use function stream_resolve_include_path;
 class PhpArray extends AbstractFileLoader
 {
     /**
-     * load(): defined by FileLoaderInterface.
-     *
-     * @see    FileLoaderInterface::load()
-     *
-     * @param  string $locale
-     * @param  string $filename
-     * @return TextDomain
      * @throws Exception\InvalidArgumentException
      */
-    public function load($locale, $filename)
+    public function load(string $locale, string $filename): TextDomain|null
     {
         $resolvedIncludePath = stream_resolve_include_path($filename);
         $fromIncludePath     = $resolvedIncludePath !== false ? $resolvedIncludePath : $filename;
@@ -43,6 +37,7 @@ class PhpArray extends AbstractFileLoader
             ));
         }
 
+        /** @psalm-suppress UnresolvableInclude */
         $messages = include $fromIncludePath;
 
         if (! is_array($messages)) {
@@ -52,16 +47,16 @@ class PhpArray extends AbstractFileLoader
             ));
         }
 
+        /** @var mixed $pluralForms */
+        $pluralForms = $messages['']['plural_forms'] ?? null;
+        unset($messages['']);
+
         $textDomain = new TextDomain($messages);
 
-        if ($textDomain->offsetExists('')) {
-            if (isset($textDomain['']['plural_forms'])) {
-                $textDomain->setPluralRule(
-                    PluralRule::fromString($textDomain['']['plural_forms'])
-                );
-            }
-
-            unset($textDomain['']);
+        if (is_string($pluralForms) && $pluralForms !== '') {
+            $textDomain->setPluralRule(
+                PluralRule::fromString($pluralForms),
+            );
         }
 
         return $textDomain;

--- a/src/Translator/Loader/PhpMemoryArray.php
+++ b/src/Translator/Loader/PhpMemoryArray.php
@@ -8,8 +8,8 @@ use Laminas\I18n\Exception;
 use Laminas\I18n\Translator\Plural\Rule as PluralRule;
 use Laminas\I18n\Translator\TextDomain;
 
-use function gettype;
 use function is_array;
+use function is_string;
 use function sprintf;
 
 /**
@@ -19,49 +19,42 @@ use function sprintf;
  */
 class PhpMemoryArray implements RemoteLoaderInterface
 {
-    /** @param array $messages */
-    public function __construct(protected $messages)
+    /** @param array<string, mixed> $messages */
+    public function __construct(private array $messages)
     {
     }
 
     /**
      * Load translations from a remote source.
      *
-     * @param  string $locale
-     * @param  string $textDomain
-     * @return TextDomain
      * @throws Exception\InvalidArgumentException
      */
-    public function load($locale, $textDomain)
+    public function load(string $locale, string $textDomain): TextDomain|null
     {
-        if (! is_array($this->messages)) {
-            throw new Exception\InvalidArgumentException(
-                sprintf('Expected an array, but received %s', gettype($this->messages))
-            );
-        }
-
         if (! isset($this->messages[$textDomain])) {
             throw new Exception\InvalidArgumentException(
                 sprintf('Expected textdomain "%s" to be an array, but it is not set', $textDomain)
             );
         }
 
-        if (! isset($this->messages[$textDomain][$locale])) {
+        $messages = $this->messages[$textDomain][$locale] ?? null;
+
+        if (! is_array($messages)) {
             throw new Exception\InvalidArgumentException(
                 sprintf('Expected locale "%s" to be an array, but it is not set', $locale)
             );
         }
 
-        $textDomain = new TextDomain($this->messages[$textDomain][$locale]);
+        /** @psalm-var mixed $pluralRule */
+        $pluralRule = $messages['']['plural_forms'] ?? null;
+        unset($messages['']);
 
-        if ($textDomain->offsetExists('')) {
-            if (isset($textDomain['']['plural_forms'])) {
-                $textDomain->setPluralRule(
-                    PluralRule::fromString($textDomain['']['plural_forms'])
-                );
-            }
+        $textDomain = new TextDomain($messages);
 
-            unset($textDomain['']);
+        if (is_string($pluralRule) && $pluralRule !== '') {
+            $textDomain->setPluralRule(
+                PluralRule::fromString($pluralRule)
+            );
         }
 
         return $textDomain;

--- a/src/Translator/Loader/RemoteLoaderInterface.php
+++ b/src/Translator/Loader/RemoteLoaderInterface.php
@@ -14,9 +14,8 @@ interface RemoteLoaderInterface
     /**
      * Load translations from a remote source.
      *
-     * @param  string $locale
-     * @param  string $textDomain
-     * @return TextDomain|null
+     * @param non-empty-string $locale
+     * @param non-empty-string $textDomain
      */
-    public function load($locale, $textDomain);
+    public function load(string $locale, string $textDomain): TextDomain|null;
 }

--- a/src/Translator/LoaderPluginManager.php
+++ b/src/Translator/LoaderPluginManager.php
@@ -24,10 +24,10 @@ use function sprintf;
  * it registers a number of default loaders.
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @psalm-import-type InstanceType from LoaderPluginManagerInterface
+ * @psalm-import-type InstanceType from MessageLoaderPluginManagerInterface
  * @extends AbstractPluginManager<InstanceType>
  */
-final class LoaderPluginManager extends AbstractPluginManager implements LoaderPluginManagerInterface
+final class LoaderPluginManager extends AbstractPluginManager implements MessageLoaderPluginManagerInterface
 {
     private const CONFIGURATION = [
         'factories' => [

--- a/src/Translator/LoaderPluginManager.php
+++ b/src/Translator/LoaderPluginManager.php
@@ -24,10 +24,10 @@ use function sprintf;
  * it registers a number of default loaders.
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @template InstanceType of RemoteLoaderInterface|FileLoaderInterface
+ * @psalm-import-type InstanceType from LoaderPluginManagerInterface
  * @extends AbstractPluginManager<InstanceType>
  */
-final class LoaderPluginManager extends AbstractPluginManager
+final class LoaderPluginManager extends AbstractPluginManager implements LoaderPluginManagerInterface
 {
     private const CONFIGURATION = [
         'factories' => [

--- a/src/Translator/LoaderPluginManagerInterface.php
+++ b/src/Translator/LoaderPluginManagerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Translator;
+
+use Laminas\I18n\Translator\Loader\FileLoaderInterface;
+use Laminas\I18n\Translator\Loader\RemoteLoaderInterface;
+use Laminas\ServiceManager\PluginManagerInterface;
+
+/**
+ * @psalm-type InstanceType = RemoteLoaderInterface|FileLoaderInterface
+ * @extends PluginManagerInterface<InstanceType>
+ */
+interface LoaderPluginManagerInterface extends PluginManagerInterface
+{
+}

--- a/src/Translator/MessageLoaderPluginManagerInterface.php
+++ b/src/Translator/MessageLoaderPluginManagerInterface.php
@@ -12,6 +12,6 @@ use Laminas\ServiceManager\PluginManagerInterface;
  * @psalm-type InstanceType = RemoteLoaderInterface|FileLoaderInterface
  * @extends PluginManagerInterface<InstanceType>
  */
-interface LoaderPluginManagerInterface extends PluginManagerInterface
+interface MessageLoaderPluginManagerInterface extends PluginManagerInterface
 {
 }

--- a/src/Translator/TextDomain.php
+++ b/src/Translator/TextDomain.php
@@ -13,9 +13,7 @@ use function array_replace;
 /**
  * Text domain.
  *
- * @template TKey of array-key
- * @template TValue
- * @extends ArrayObject<TKey, TValue>
+ * @extends ArrayObject<non-empty-string, non-empty-string|list<string|null>>
  * @final
  */
 class TextDomain extends ArrayObject
@@ -48,10 +46,9 @@ class TextDomain extends ArrayObject
     /**
      * Get the plural rule.
      *
-     * @param  bool $fallbackToDefaultRule
-     * @return PluralRule|null
+     * @psalm-return ($fallbackToDefaultRule is true ? PluralRule : PluralRule|null)
      */
-    public function getPluralRule($fallbackToDefaultRule = true)
+    public function getPluralRule(bool $fallbackToDefaultRule = true): PluralRule|null
     {
         if ($this->pluralRule === null && $fallbackToDefaultRule) {
             return static::getDefaultPluralRule();
@@ -93,12 +90,8 @@ class TextDomain extends ArrayObject
      *
      * @return $this
      * @throws Exception\RuntimeException
-     * @template TNewKey of array-key
-     * @template TNewValue
-     * @param self<TNewKey, TNewValue> $textDomain
-     * @psalm-self-out self<TKey|TNewKey, TValue|TNewValue>
      */
-    public function merge(TextDomain $textDomain)
+    public function merge(TextDomain $textDomain): self
     {
         if ($this->hasPluralRule() && $textDomain->hasPluralRule()) {
             if ($this->getPluralRule()->getNumPlurals() !== $textDomain->getPluralRule()->getNumPlurals()) {

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -10,7 +10,6 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\I18n\Exception;
 use Laminas\I18n\Translator\Loader\FileLoaderInterface;
 use Laminas\I18n\Translator\Loader\RemoteLoaderInterface;
-use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Translator\TranslatorInterface;
 use Locale;
@@ -88,13 +87,6 @@ class Translator implements TranslatorInterface
     private CacheItemPoolInterface|null $cache = null;
 
     /**
-     * Plugin manager for translation loaders.
-     *
-     * @var LoaderPluginManager
-     */
-    protected $pluginManager;
-
-    /**
      * Event manager for triggering translator events.
      *
      * @var EventManagerInterface
@@ -108,6 +100,11 @@ class Translator implements TranslatorInterface
      */
     protected $eventsEnabled = false;
 
+    public function __construct(
+        private LoaderPluginManager $pluginManager,
+    ) {
+    }
+
     /**
      * Instantiate a translator
      *
@@ -115,7 +112,7 @@ class Translator implements TranslatorInterface
      * @return static
      * @throws Exception\InvalidArgumentException
      */
-    public static function factory($options)
+    public static function factory(LoaderPluginManager $pluginManager, $options)
     {
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
@@ -127,7 +124,7 @@ class Translator implements TranslatorInterface
             ));
         }
 
-        $translator = new static();
+        $translator = new self($pluginManager);
 
         // locales
         if (isset($options['locale'])) {
@@ -142,7 +139,7 @@ class Translator implements TranslatorInterface
         if (isset($options['translation_file_patterns'])) {
             if (! is_array($options['translation_file_patterns'])) {
                 throw new Exception\InvalidArgumentException(
-                    '"translation_file_patterns" should be an array'
+                    '"translation_file_patterns" should be an array',
                 );
             }
 
@@ -151,7 +148,7 @@ class Translator implements TranslatorInterface
                 foreach ($requiredKeys as $key) {
                     if (! isset($pattern[$key])) {
                         throw new Exception\InvalidArgumentException(
-                            "'{$key}' is missing for translation pattern options"
+                            "'{$key}' is missing for translation pattern options",
                         );
                     }
                 }
@@ -160,7 +157,7 @@ class Translator implements TranslatorInterface
                     $pattern['type'],
                     $pattern['base_dir'],
                     $pattern['pattern'],
-                    $pattern['text_domain'] ?? 'default'
+                    $pattern['text_domain'] ?? 'default',
                 );
             }
         }
@@ -169,7 +166,7 @@ class Translator implements TranslatorInterface
         if (isset($options['translation_files'])) {
             if (! is_array($options['translation_files'])) {
                 throw new Exception\InvalidArgumentException(
-                    '"translation_files" should be an array'
+                    '"translation_files" should be an array',
                 );
             }
 
@@ -178,7 +175,7 @@ class Translator implements TranslatorInterface
                 foreach ($requiredKeys as $key) {
                     if (! isset($file[$key])) {
                         throw new Exception\InvalidArgumentException(
-                            "'{$key}' is missing for translation file options"
+                            "'{$key}' is missing for translation file options",
                         );
                     }
                 }
@@ -187,7 +184,7 @@ class Translator implements TranslatorInterface
                     $file['type'],
                     $file['filename'],
                     $file['text_domain'] ?? 'default',
-                    $file['locale'] ?? null
+                    $file['locale'] ?? null,
                 );
             }
         }
@@ -196,7 +193,7 @@ class Translator implements TranslatorInterface
         if (isset($options['remote_translation'])) {
             if (! is_array($options['remote_translation'])) {
                 throw new Exception\InvalidArgumentException(
-                    '"remote_translation" should be an array'
+                    '"remote_translation" should be an array',
                 );
             }
 
@@ -205,14 +202,14 @@ class Translator implements TranslatorInterface
                 foreach ($requiredKeys as $key) {
                     if (! isset($remote[$key])) {
                         throw new Exception\InvalidArgumentException(
-                            "'{$key}' is missing for remote translation options"
+                            "'{$key}' is missing for remote translation options",
                         );
                     }
                 }
 
                 $translator->addRemoteTranslations(
                     $remote['type'],
-                    $remote['text_domain'] ?? 'default'
+                    $remote['text_domain'] ?? 'default',
                 );
             }
         }
@@ -295,34 +292,6 @@ class Translator implements TranslatorInterface
     }
 
     /**
-     * Set the plugin manager for translation loaders
-     *
-     * @return $this
-     */
-    public function setPluginManager(LoaderPluginManager $pluginManager)
-    {
-        $this->pluginManager = $pluginManager;
-
-        return $this;
-    }
-
-    /**
-     * Retrieve the plugin manager for translation loaders.
-     *
-     * Lazy loads an instance if none currently set.
-     *
-     * @return LoaderPluginManager
-     */
-    public function getPluginManager()
-    {
-        if (! $this->pluginManager instanceof LoaderPluginManager) {
-            $this->setPluginManager(new LoaderPluginManager(new ServiceManager()));
-        }
-
-        return $this->pluginManager;
-    }
-
-    /**
      * Translate a message.
      *
      * @param  string      $message
@@ -366,7 +335,7 @@ class Translator implements TranslatorInterface
         $plural,
         $number,
         $textDomain = 'default',
-        $locale = null
+        $locale = null,
     ) {
         $locale    ??= $this->getLocale();
         $translation = $this->getTranslatedMessage($singular, $locale, $textDomain);
@@ -395,7 +364,7 @@ class Translator implements TranslatorInterface
                 $plural,
                 $number,
                 $textDomain,
-                $fallbackLocale
+                $fallbackLocale,
             );
         }
 
@@ -414,7 +383,7 @@ class Translator implements TranslatorInterface
     protected function getTranslatedMessage(
         $message,
         $locale,
-        $textDomain = 'default'
+        $textDomain = 'default',
     ) {
         if ($message === '' || $message === null) {
             return '';
@@ -478,7 +447,7 @@ class Translator implements TranslatorInterface
         $type,
         $filename,
         $textDomain = 'default',
-        $locale = null
+        $locale = null,
     ) {
         $locale ??= '*';
 
@@ -507,7 +476,7 @@ class Translator implements TranslatorInterface
         $type,
         $baseDir,
         $pattern,
-        $textDomain = 'default'
+        $textDomain = 'default',
     ) {
         if (! isset($this->patterns[$textDomain])) {
             $this->patterns[$textDomain] = [];
@@ -634,7 +603,7 @@ class Translator implements TranslatorInterface
 
         if (isset($this->remote[$textDomain])) {
             foreach ($this->remote[$textDomain] as $loaderType) {
-                $loader = $this->getPluginManager()->get($loaderType);
+                $loader = $this->pluginManager->get($loaderType);
 
                 if (! $loader instanceof RemoteLoaderInterface) {
                     throw new Exception\RuntimeException('Specified loader is not a remote loader');
@@ -670,7 +639,7 @@ class Translator implements TranslatorInterface
                 $filename = $pattern['baseDir'] . '/' . sprintf($pattern['pattern'], $locale);
 
                 if (is_file($filename)) {
-                    $loader = $this->getPluginManager()->get($pattern['type']);
+                    $loader = $this->pluginManager->get($pattern['type']);
 
                     if (! $loader instanceof FileLoaderInterface) {
                         throw new Exception\RuntimeException('Specified loader is not a file loader');
@@ -708,7 +677,7 @@ class Translator implements TranslatorInterface
             }
 
             foreach ($this->files[$textDomain][$currentLocale] as $file) {
-                $loader = $this->getPluginManager()->get($file['type']);
+                $loader = $this->pluginManager->get($file['type']);
 
                 if (! $loader instanceof FileLoaderInterface) {
                     throw new Exception\RuntimeException('Specified loader is not a file loader');

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -31,7 +31,7 @@ use const DIRECTORY_SEPARATOR;
 /**
  * Translator.
  *
- * @psalm-type FileEntry = array{type: non-empty-string, filename: non-empty-string|null}
+ * @psalm-type FileEntry = array{type: non-empty-string, filename: non-empty-string}
  * @psalm-type FileList = array<non-empty-string, array<non-empty-string, list<FileEntry>>>
  * @psalm-type FilePatternList = array<non-empty-string, list<TranslatorFilePattern>>
  * @final
@@ -436,14 +436,14 @@ class Translator implements TranslatorInterface
      * Add a translation file.
      *
      * @param non-empty-string $type
-     * @param non-empty-string|null $filename
+     * @param non-empty-string $filename
      * @param non-empty-string $textDomain
      * @param non-empty-string|null $locale
      * @return $this
      */
     public function addTranslationFile(
         string $type,
-        string|null $filename,
+        string $filename,
         string $textDomain = self::DEFAULT_TEXT_DOMAIN,
         string|null $locale = null,
     ): self {

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -17,17 +17,23 @@ use Psr\Cache\CacheItemPoolInterface;
 use Traversable;
 
 use function array_shift;
+use function assert;
 use function get_debug_type;
 use function is_array;
 use function is_file;
 use function is_string;
 use function md5;
+use function realpath;
 use function rtrim;
 use function sprintf;
 
 /**
  * Translator.
  *
+ * @psalm-type FileEntry = array{type: non-empty-string, filename: non-empty-string|null}
+ * @psalm-type FileList = array<non-empty-string, array<non-empty-string, list<FileEntry>>>
+ * @psalm-type FilePatternEntry = array{type: non-empty-string, baseDir: non-empty-string, pattern: non-empty-string}
+ * @psalm-type FilePatternList = array<non-empty-string, list<FilePatternEntry>>
  * @final
  */
 class Translator implements TranslatorInterface
@@ -45,44 +51,44 @@ class Translator implements TranslatorInterface
     /**
      * Messages loaded by the translator.
      *
-     * @var array
+     * @var array<non-empty-string, array<non-empty-string, TextDomain|null>>
      */
-    protected $messages = [];
+    private array $messages = [];
 
     /**
      * Files used for loading messages.
      *
-     * @var array
+     * @var FileList
      */
-    protected $files = [];
+    private array $files = [];
 
     /**
      * Patterns used for loading messages.
      *
-     * @var array
+     * @var FilePatternList
      */
-    protected $patterns = [];
+    private array $patterns = [];
 
     /**
      * Remote locations for loading messages.
      *
-     * @var array
+     * @var array<non-empty-string, list<non-empty-string>>
      */
-    protected $remote = [];
+    private array $remote = [];
 
     /**
      * Default locale.
      *
-     * @var string|null
+     * @var non-empty-string|null
      */
-    protected $locale;
+    private string|null $locale = null;
 
     /**
      * Locale to use as fallback if there is no translation.
      *
-     * @var string|null
+     * @var non-empty-string|null
      */
-    protected $fallbackLocale;
+    private string|null $fallbackLocale = null;
 
     private CacheItemPoolInterface|null $cache = null;
 
@@ -234,10 +240,10 @@ class Translator implements TranslatorInterface
     /**
      * Set the default locale.
      *
-     * @param  string|null $locale
+     * @param non-empty-string $locale
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): self
     {
         $this->locale = $locale;
 
@@ -247,12 +253,15 @@ class Translator implements TranslatorInterface
     /**
      * Get the default locale.
      *
-     * @return string
+     * @return non-empty-string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         if ($this->locale === null) {
-            $this->locale = Locale::getDefault();
+            $default = Locale::getDefault();
+            assert($default !== '');
+
+            $this->locale = $default;
         }
 
         return $this->locale;
@@ -261,10 +270,10 @@ class Translator implements TranslatorInterface
     /**
      * Set the fallback locale.
      *
-     * @param  string|null $locale
+     * @param non-empty-string|null $locale
      * @return $this
      */
-    public function setFallbackLocale($locale)
+    public function setFallbackLocale(string|null $locale): self
     {
         $this->fallbackLocale = $locale;
 
@@ -273,10 +282,8 @@ class Translator implements TranslatorInterface
 
     /**
      * Get the fallback locale.
-     *
-     * @return string|null
      */
-    public function getFallbackLocale()
+    public function getFallbackLocale(): string|null
     {
         return $this->fallbackLocale;
     }
@@ -296,26 +303,22 @@ class Translator implements TranslatorInterface
     /**
      * Translate a message.
      *
-     * @param  string      $message
-     * @param  string      $textDomain
-     * @param  string|null $locale
-     * @return string
+     * @param non-empty-string $message
+     * @param non-empty-string $textDomain
+     * @param non-empty-string|null $locale
+     * @psalm-suppress MoreSpecificImplementedParamType This will be redundant when Translator interface is improved
      */
-    public function translate($message, $textDomain = 'default', $locale = null)
+    public function translate($message, $textDomain = 'default', $locale = null): string|null
     {
-        $locale      = $locale === '' ? null : $locale;
         $locale    ??= $this->getLocale();
         $translation = $this->getTranslatedMessage($message, $locale, $textDomain);
 
-        if ($translation !== null && $translation !== '') {
+        if (is_string($translation) && $translation !== '') {
             return $translation;
         }
 
-        if (
-            null !== ($fallbackLocale = $this->getFallbackLocale())
-            && $locale !== $fallbackLocale
-        ) {
-            return $this->translate($message, $textDomain, $fallbackLocale);
+        if ($this->fallbackLocale !== null && $locale !== $this->fallbackLocale) {
+            return $this->translate($message, $textDomain, $this->fallbackLocale);
         }
 
         return $message;
@@ -327,10 +330,11 @@ class Translator implements TranslatorInterface
      * @param  string      $singular
      * @param  string      $plural
      * @param  int         $number
-     * @param  string      $textDomain
-     * @param  string|null $locale
+     * @param  non-empty-string $textDomain
+     * @param  non-empty-string|null $locale
      * @return string
      * @throws Exception\OutOfBoundsException
+     * @psalm-suppress MoreSpecificImplementedParamType This will be redundant when Translator interface is improved
      */
     public function translatePlural(
         $singular,
@@ -348,25 +352,21 @@ class Translator implements TranslatorInterface
 
         $index = $number === 1 ? 0 : 1; // en_EN Plural rule
         if ($this->messages[$textDomain][$locale] instanceof TextDomain) {
-            $index = $this->messages[$textDomain][$locale]
-                ->getPluralRule()
-                ->evaluate($number);
+            $index = (int) $this->messages[$textDomain][$locale]
+                ->getPluralRule()->evaluate($number);
         }
 
         if (isset($translation[$index]) && $translation[$index] !== '' && $translation[$index] !== null) {
             return $translation[$index];
         }
 
-        if (
-            null !== ($fallbackLocale = $this->getFallbackLocale())
-            && $locale !== $fallbackLocale
-        ) {
+        if ($this->fallbackLocale !== null && $locale !== $this->fallbackLocale) {
             return $this->translatePlural(
                 $singular,
                 $plural,
                 $number,
                 $textDomain,
-                $fallbackLocale,
+                $this->fallbackLocale,
             );
         }
 
@@ -377,18 +377,17 @@ class Translator implements TranslatorInterface
      * Get a translated message.
      *
      * @triggers getTranslatedMessage.missing-translation
-     * @param    string $message
-     * @param    string $locale
-     * @param    string $textDomain
-     * @return   string|null
+     * @param non-empty-string $locale
+     * @param non-empty-string $textDomain
+     * @return string|null|list<string|null>
      */
     protected function getTranslatedMessage(
-        $message,
-        $locale,
-        $textDomain = 'default',
-    ) {
+        string|null $message,
+        string $locale,
+        string $textDomain = 'default',
+    ): string|array|null {
         if ($message === '' || $message === null) {
-            return '';
+            return null;
         }
 
         if (! isset($this->messages[$textDomain][$locale])) {
@@ -402,14 +401,14 @@ class Translator implements TranslatorInterface
         /**
          * issue https://github.com/zendframework/zend-i18n/issues/53
          *
-         * storage: array:8 [▼
-         *   "default\x04Welcome" => "Cześć"
-         *   "default\x04Top %s Product" => array:3 [▼
+         * storage: [
+         *   "default\x04Welcome" => "Cześć",
+         *   "default\x04Top %s Product" => [
          *     0 => "Top %s Produkt"
          *     1 => "Top %s Produkty"
          *     2 => "Top %s Produktów"
-         *   ]
-         *   "Top %s Products" => ""
+         *   ],
+         *   "Top %s Products" => "",
          * ]
          */
         if (isset($this->messages[$textDomain][$locale][$textDomain . "\x04" . $message])) {
@@ -417,7 +416,7 @@ class Translator implements TranslatorInterface
         }
 
         if ($this->isEventManagerEnabled()) {
-            $until = static fn($r): bool => is_string($r);
+            $until = static fn(mixed $r): bool => is_string($r);
 
             $event = new Event(self::EVENT_MISSING_TRANSLATION, $this, [
                 'message'     => $message,
@@ -439,18 +438,18 @@ class Translator implements TranslatorInterface
     /**
      * Add a translation file.
      *
-     * @param  string      $type
-     * @param  string      $filename
-     * @param  string      $textDomain
-     * @param  string|null $locale
+     * @param non-empty-string $type
+     * @param non-empty-string|null $filename
+     * @param non-empty-string $textDomain
+     * @param non-empty-string|null $locale
      * @return $this
      */
     public function addTranslationFile(
-        $type,
-        $filename,
-        $textDomain = 'default',
-        $locale = null,
-    ) {
+        string $type,
+        string|null $filename,
+        string $textDomain = 'default',
+        string|null $locale = null,
+    ): self {
         $locale ??= '*';
 
         if (! isset($this->files[$textDomain])) {
@@ -468,25 +467,28 @@ class Translator implements TranslatorInterface
     /**
      * Add multiple translations with a file pattern.
      *
-     * @param  string $type
-     * @param  string $baseDir
-     * @param  string $pattern
-     * @param  string $textDomain
+     * @param non-empty-string $type
+     * @param non-empty-string $baseDir
+     * @param non-empty-string $pattern
+     * @param non-empty-string $textDomain
      * @return $this
      */
     public function addTranslationFilePattern(
-        $type,
-        $baseDir,
-        $pattern,
-        $textDomain = 'default',
-    ) {
+        string $type,
+        string $baseDir,
+        string $pattern,
+        string $textDomain = 'default',
+    ): self {
         if (! isset($this->patterns[$textDomain])) {
             $this->patterns[$textDomain] = [];
         }
 
+        $baseDir = realpath(rtrim($baseDir, '/'));
+        assert(is_string($baseDir) && $baseDir !== '');
+
         $this->patterns[$textDomain][] = [
             'type'    => $type,
-            'baseDir' => rtrim($baseDir, '/'),
+            'baseDir' => $baseDir,
             'pattern' => $pattern,
         ];
 
@@ -496,11 +498,11 @@ class Translator implements TranslatorInterface
     /**
      * Add remote translations.
      *
-     * @param  string $type
-     * @param  string $textDomain
+     * @param non-empty-string $type
+     * @param non-empty-string $textDomain
      * @return $this
      */
-    public function addRemoteTranslations($type, $textDomain = 'default')
+    public function addRemoteTranslations(string $type, string $textDomain = 'default'): self
     {
         if (! isset($this->remote[$textDomain])) {
             $this->remote[$textDomain] = [];
@@ -538,10 +540,12 @@ class Translator implements TranslatorInterface
     /**
      * Load messages for a given language and domain.
      *
+     * @param non-empty-string $textDomain
+     * @param non-empty-string $locale
      * @triggers loadMessages.no-messages-loaded
      * @throws Exception\RuntimeException
      */
-    protected function loadMessages(string $textDomain, string $locale): void
+    private function loadMessages(string $textDomain, string $locale): void
     {
         if (! isset($this->messages[$textDomain])) {
             $this->messages[$textDomain] = [];
@@ -551,7 +555,10 @@ class Translator implements TranslatorInterface
             $cacheId = $this->getCacheId($textDomain, $locale);
             $item    = $this->cache->getItem($cacheId);
             if ($item->isHit()) {
-                $this->messages[$textDomain][$locale] = $item->get();
+                $value = $item->get();
+                assert($value instanceof TextDomain);
+
+                $this->messages[$textDomain][$locale] = $value;
 
                 return;
             }
@@ -594,12 +601,11 @@ class Translator implements TranslatorInterface
     /**
      * Load messages from remote sources.
      *
-     * @param  string $textDomain
-     * @param  string $locale
-     * @return bool
+     * @param non-empty-string $textDomain
+     * @param non-empty-string $locale
      * @throws Exception\RuntimeException When specified loader is not a remote loader.
      */
-    protected function loadMessagesFromRemote($textDomain, $locale)
+    private function loadMessagesFromRemote(string $textDomain, string $locale): bool
     {
         $messagesLoaded = false;
 
@@ -611,10 +617,15 @@ class Translator implements TranslatorInterface
                     throw new Exception\RuntimeException('Specified loader is not a remote loader');
                 }
 
+                $loadedTextDomain = $loader->load($locale, $textDomain);
+                if ($loadedTextDomain === null) {
+                    continue;
+                }
+
                 if (isset($this->messages[$textDomain][$locale])) {
-                    $this->messages[$textDomain][$locale]->merge($loader->load($locale, $textDomain));
+                    $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
                 } else {
-                    $this->messages[$textDomain][$locale] = $loader->load($locale, $textDomain);
+                    $this->messages[$textDomain][$locale] = $loadedTextDomain;
                 }
 
                 $messagesLoaded = true;
@@ -627,12 +638,11 @@ class Translator implements TranslatorInterface
     /**
      * Load messages from patterns.
      *
-     * @param  string $textDomain
-     * @param  string $locale
-     * @return bool
+     * @param non-empty-string $textDomain
+     * @param non-empty-string $locale
      * @throws Exception\RuntimeException When specified loader is not a file loader.
      */
-    protected function loadMessagesFromPatterns($textDomain, $locale)
+    private function loadMessagesFromPatterns(string $textDomain, string $locale): bool
     {
         $messagesLoaded = false;
 
@@ -647,10 +657,15 @@ class Translator implements TranslatorInterface
                         throw new Exception\RuntimeException('Specified loader is not a file loader');
                     }
 
+                    $loadedTextDomain = $loader->load($locale, $filename);
+                    if ($loadedTextDomain === null) {
+                        continue;
+                    }
+
                     if (isset($this->messages[$textDomain][$locale])) {
-                        $this->messages[$textDomain][$locale]->merge($loader->load($locale, $filename));
+                        $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
                     } else {
-                        $this->messages[$textDomain][$locale] = $loader->load($locale, $filename);
+                        $this->messages[$textDomain][$locale] = $loadedTextDomain;
                     }
 
                     $messagesLoaded = true;
@@ -664,12 +679,11 @@ class Translator implements TranslatorInterface
     /**
      * Load messages from files.
      *
-     * @param  string $textDomain
-     * @param  string $locale
-     * @return bool
+     * @param non-empty-string $textDomain
+     * @param non-empty-string $locale
      * @throws Exception\RuntimeException When specified loader is not a file loader.
      */
-    protected function loadMessagesFromFiles($textDomain, $locale)
+    private function loadMessagesFromFiles(string $textDomain, string $locale): bool
     {
         $messagesLoaded = false;
 
@@ -685,10 +699,15 @@ class Translator implements TranslatorInterface
                     throw new Exception\RuntimeException('Specified loader is not a file loader');
                 }
 
+                $loadedTextDomain = $loader->load($locale, $file['filename']);
+                if ($loadedTextDomain === null) {
+                    continue;
+                }
+
                 if (isset($this->messages[$textDomain][$locale])) {
-                    $this->messages[$textDomain][$locale]->merge($loader->load($locale, $file['filename']));
+                    $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
                 } else {
-                    $this->messages[$textDomain][$locale] = $loader->load($locale, $file['filename']);
+                    $this->messages[$textDomain][$locale] = $loadedTextDomain;
                 }
 
                 $messagesLoaded = true;
@@ -703,11 +722,10 @@ class Translator implements TranslatorInterface
     /**
      * Return all the messages.
      *
-     * @param string      $textDomain
-     * @param string|null $locale
-     * @return mixed
+     * @param non-empty-string $textDomain
+     * @param non-empty-string|null $locale
      */
-    public function getAllMessages($textDomain = 'default', $locale = null)
+    public function getAllMessages(string $textDomain = 'default', string|null $locale = null): TextDomain|null
     {
         $locale ??= $this->getLocale();
 

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -10,6 +10,7 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\I18n\Exception;
 use Laminas\I18n\Translator\Loader\FileLoaderInterface;
 use Laminas\I18n\Translator\Loader\RemoteLoaderInterface;
+use Laminas\I18n\Translator\Value\TranslatorFilePattern;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Translator\TranslatorInterface;
 use Locale;
@@ -23,21 +24,22 @@ use function is_array;
 use function is_file;
 use function is_string;
 use function md5;
-use function realpath;
-use function rtrim;
 use function sprintf;
+
+use const DIRECTORY_SEPARATOR;
 
 /**
  * Translator.
  *
  * @psalm-type FileEntry = array{type: non-empty-string, filename: non-empty-string|null}
  * @psalm-type FileList = array<non-empty-string, array<non-empty-string, list<FileEntry>>>
- * @psalm-type FilePatternEntry = array{type: non-empty-string, baseDir: non-empty-string, pattern: non-empty-string}
- * @psalm-type FilePatternList = array<non-empty-string, list<FilePatternEntry>>
+ * @psalm-type FilePatternList = array<non-empty-string, list<TranslatorFilePattern>>
  * @final
  */
 class Translator implements TranslatorInterface
 {
+    public const DEFAULT_TEXT_DOMAIN = 'default';
+
     /**
      * Event fired when the translation for a message is missing.
      */
@@ -151,22 +153,17 @@ class Translator implements TranslatorInterface
                 );
             }
 
-            $requiredKeys = ['type', 'base_dir', 'pattern'];
-            foreach ($options['translation_file_patterns'] as $pattern) {
-                foreach ($requiredKeys as $key) {
-                    if (! isset($pattern[$key])) {
-                        throw new Exception\InvalidArgumentException(
-                            "'{$key}' is missing for translation pattern options",
-                        );
-                    }
+            foreach ($options['translation_file_patterns'] as $spec) {
+                if (! is_array($spec)) {
+                    continue;
                 }
 
-                $translator->addTranslationFilePattern(
-                    $pattern['type'],
-                    $pattern['base_dir'],
-                    $pattern['pattern'],
-                    $pattern['text_domain'] ?? 'default',
+                $pattern = TranslatorFilePattern::fromArray(
+                    $spec,
+                    self::DEFAULT_TEXT_DOMAIN,
                 );
+
+                $translator->patterns[$pattern->textDomain][] = $pattern;
             }
         }
 
@@ -191,7 +188,7 @@ class Translator implements TranslatorInterface
                 $translator->addTranslationFile(
                     $file['type'],
                     $file['filename'],
-                    $file['text_domain'] ?? 'default',
+                    $file['text_domain'] ?? self::DEFAULT_TEXT_DOMAIN,
                     $file['locale'] ?? null,
                 );
             }
@@ -217,7 +214,7 @@ class Translator implements TranslatorInterface
 
                 $translator->addRemoteTranslations(
                     $remote['type'],
-                    $remote['text_domain'] ?? 'default',
+                    $remote['text_domain'] ?? self::DEFAULT_TEXT_DOMAIN,
                 );
             }
         }
@@ -308,7 +305,7 @@ class Translator implements TranslatorInterface
      * @param non-empty-string|null $locale
      * @psalm-suppress MoreSpecificImplementedParamType This will be redundant when Translator interface is improved
      */
-    public function translate($message, $textDomain = 'default', $locale = null): string|null
+    public function translate($message, $textDomain = self::DEFAULT_TEXT_DOMAIN, $locale = null): string|null
     {
         $locale    ??= $this->getLocale();
         $translation = $this->getTranslatedMessage($message, $locale, $textDomain);
@@ -340,7 +337,7 @@ class Translator implements TranslatorInterface
         $singular,
         $plural,
         $number,
-        $textDomain = 'default',
+        $textDomain = self::DEFAULT_TEXT_DOMAIN,
         $locale = null,
     ) {
         $locale    ??= $this->getLocale();
@@ -384,7 +381,7 @@ class Translator implements TranslatorInterface
     protected function getTranslatedMessage(
         string|null $message,
         string $locale,
-        string $textDomain = 'default',
+        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
     ): string|array|null {
         if ($message === '' || $message === null) {
             return null;
@@ -447,7 +444,7 @@ class Translator implements TranslatorInterface
     public function addTranslationFile(
         string $type,
         string|null $filename,
-        string $textDomain = 'default',
+        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
         string|null $locale = null,
     ): self {
         $locale ??= '*';
@@ -477,20 +474,17 @@ class Translator implements TranslatorInterface
         string $type,
         string $baseDir,
         string $pattern,
-        string $textDomain = 'default',
+        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
     ): self {
-        if (! isset($this->patterns[$textDomain])) {
-            $this->patterns[$textDomain] = [];
-        }
+        $pattern = new TranslatorFilePattern(
+            $type,
+            $baseDir,
+            $pattern,
+            $textDomain,
+        );
 
-        $baseDir = realpath(rtrim($baseDir, '/'));
-        assert(is_string($baseDir) && $baseDir !== '');
-
-        $this->patterns[$textDomain][] = [
-            'type'    => $type,
-            'baseDir' => $baseDir,
-            'pattern' => $pattern,
-        ];
+        $this->patterns[$pattern->textDomain] ??= [];
+        $this->patterns[$pattern->textDomain][] = $pattern;
 
         return $this;
     }
@@ -502,7 +496,7 @@ class Translator implements TranslatorInterface
      * @param non-empty-string $textDomain
      * @return $this
      */
-    public function addRemoteTranslations(string $type, string $textDomain = 'default'): self
+    public function addRemoteTranslations(string $type, string $textDomain = self::DEFAULT_TEXT_DOMAIN): self
     {
         if (! isset($this->remote[$textDomain])) {
             $this->remote[$textDomain] = [];
@@ -648,28 +642,35 @@ class Translator implements TranslatorInterface
 
         if (isset($this->patterns[$textDomain])) {
             foreach ($this->patterns[$textDomain] as $pattern) {
-                $filename = $pattern['baseDir'] . '/' . sprintf($pattern['pattern'], $locale);
+                $filename = sprintf(
+                    '%s%s%s',
+                    $pattern->baseDirectory,
+                    DIRECTORY_SEPARATOR,
+                    sprintf($pattern->pattern, $locale),
+                );
 
-                if (is_file($filename)) {
-                    $loader = $this->pluginManager->get($pattern['type']);
-
-                    if (! $loader instanceof FileLoaderInterface) {
-                        throw new Exception\RuntimeException('Specified loader is not a file loader');
-                    }
-
-                    $loadedTextDomain = $loader->load($locale, $filename);
-                    if ($loadedTextDomain === null) {
-                        continue;
-                    }
-
-                    if (isset($this->messages[$textDomain][$locale])) {
-                        $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
-                    } else {
-                        $this->messages[$textDomain][$locale] = $loadedTextDomain;
-                    }
-
-                    $messagesLoaded = true;
+                if (! is_file($filename)) {
+                    continue;
                 }
+
+                $loader = $this->pluginManager->get($pattern->type);
+
+                if (! $loader instanceof FileLoaderInterface) {
+                    throw new Exception\RuntimeException('Specified loader is not a file loader');
+                }
+
+                $loadedTextDomain = $loader->load($locale, $filename);
+                if ($loadedTextDomain === null) {
+                    continue;
+                }
+
+                if (isset($this->messages[$textDomain][$locale])) {
+                    $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
+                } else {
+                    $this->messages[$textDomain][$locale] = $loadedTextDomain;
+                }
+
+                $messagesLoaded = true;
             }
         }
 
@@ -725,8 +726,10 @@ class Translator implements TranslatorInterface
      * @param non-empty-string $textDomain
      * @param non-empty-string|null $locale
      */
-    public function getAllMessages(string $textDomain = 'default', string|null $locale = null): TextDomain|null
-    {
+    public function getAllMessages(
+        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
+        string|null $locale = null,
+    ): TextDomain|null {
         $locale ??= $this->getLocale();
 
         if (! isset($this->messages[$textDomain][$locale])) {

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -10,6 +10,7 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\I18n\Exception;
 use Laminas\I18n\Translator\Loader\FileLoaderInterface;
 use Laminas\I18n\Translator\Loader\RemoteLoaderInterface;
+use Laminas\I18n\Translator\Value\TranslationFile;
 use Laminas\I18n\Translator\Value\TranslatorFilePattern;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Translator\TranslatorInterface;
@@ -31,14 +32,14 @@ use const DIRECTORY_SEPARATOR;
 /**
  * Translator.
  *
- * @psalm-type FileEntry = array{type: non-empty-string, filename: non-empty-string}
- * @psalm-type FileList = array<non-empty-string, array<non-empty-string, list<FileEntry>>>
+ * @psalm-type FileList = array<non-empty-string, array<non-empty-string, list<TranslationFile>>>
  * @psalm-type FilePatternList = array<non-empty-string, list<TranslatorFilePattern>>
  * @final
  */
 class Translator implements TranslatorInterface
 {
     public const DEFAULT_TEXT_DOMAIN = 'default';
+    public const ANY_LOCALE          = '*';
 
     /**
      * Event fired when the translation for a message is missing.
@@ -175,22 +176,17 @@ class Translator implements TranslatorInterface
                 );
             }
 
-            $requiredKeys = ['type', 'filename'];
-            foreach ($options['translation_files'] as $file) {
-                foreach ($requiredKeys as $key) {
-                    if (! isset($file[$key])) {
-                        throw new Exception\InvalidArgumentException(
-                            "'{$key}' is missing for translation file options",
-                        );
-                    }
+            /** @psalm-var mixed $spec */
+            foreach ($options['translation_files'] as $spec) {
+                if (! is_array($spec)) {
+                    continue;
                 }
 
-                $translator->addTranslationFile(
-                    $file['type'],
-                    $file['filename'],
-                    $file['text_domain'] ?? self::DEFAULT_TEXT_DOMAIN,
-                    $file['locale'] ?? null,
-                );
+                $file = TranslationFile::fromArray($spec, self::ANY_LOCALE, self::DEFAULT_TEXT_DOMAIN);
+
+                $translator->files[$file->textDomain]                ??= [];
+                $translator->files[$file->textDomain][$file->locale] ??= [];
+                $translator->files[$file->textDomain][$file->locale][] = $file;
             }
         }
 
@@ -437,26 +433,28 @@ class Translator implements TranslatorInterface
      *
      * @param non-empty-string $type
      * @param non-empty-string $filename
-     * @param non-empty-string $textDomain
+     * @param non-empty-string|null $textDomain
      * @param non-empty-string|null $locale
      * @return $this
      */
     public function addTranslationFile(
         string $type,
         string $filename,
-        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
+        string|null $textDomain = null,
         string|null $locale = null,
     ): self {
-        $locale ??= '*';
+        $file = TranslationFile::fromArray(
+            [
+                'type'     => $type,
+                'filename' => $filename,
+            ],
+            $locale ?? self::ANY_LOCALE,
+            $textDomain ?? self::DEFAULT_TEXT_DOMAIN,
+        );
 
-        if (! isset($this->files[$textDomain])) {
-            $this->files[$textDomain] = [];
-        }
-
-        $this->files[$textDomain][$locale][] = [
-            'type'     => $type,
-            'filename' => $filename,
-        ];
+        $this->files[$file->textDomain]                ??= [];
+        $this->files[$file->textDomain][$file->locale] ??= [];
+        $this->files[$file->textDomain][$file->locale][] = $file;
 
         return $this;
     }
@@ -541,9 +539,7 @@ class Translator implements TranslatorInterface
      */
     private function loadMessages(string $textDomain, string $locale): void
     {
-        if (! isset($this->messages[$textDomain])) {
-            $this->messages[$textDomain] = [];
-        }
+        $this->messages[$textDomain] ??= [];
 
         if ($this->cache !== null) {
             $cacheId = $this->getCacheId($textDomain, $locale);
@@ -566,7 +562,7 @@ class Translator implements TranslatorInterface
         if ($messagesLoaded === 0) {
             $discoveredTextDomain = null;
             if ($this->isEventManagerEnabled()) {
-                $until = static fn($r): bool => $r instanceof TextDomain;
+                $until = static fn(mixed $r): bool => $r instanceof TextDomain;
 
                 $event = new Event(self::EVENT_NO_MESSAGES_LOADED, $this, [
                     'locale'      => $locale,
@@ -581,7 +577,7 @@ class Translator implements TranslatorInterface
                 }
             }
 
-            $this->messages[$textDomain][$locale] = $discoveredTextDomain;
+            $this->insertLoadedTextDomain($discoveredTextDomain, $textDomain, $locale);
         }
 
         if ($this->cache !== null) {
@@ -611,16 +607,11 @@ class Translator implements TranslatorInterface
                     throw new Exception\RuntimeException('Specified loader is not a remote loader');
                 }
 
-                $loadedTextDomain = $loader->load($locale, $textDomain);
-                if ($loadedTextDomain === null) {
-                    continue;
-                }
-
-                if (isset($this->messages[$textDomain][$locale])) {
-                    $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
-                } else {
-                    $this->messages[$textDomain][$locale] = $loadedTextDomain;
-                }
+                $this->insertLoadedTextDomain(
+                    $loader->load($locale, $textDomain),
+                    $textDomain,
+                    $locale,
+                );
 
                 $messagesLoaded = true;
             }
@@ -659,16 +650,11 @@ class Translator implements TranslatorInterface
                     throw new Exception\RuntimeException('Specified loader is not a file loader');
                 }
 
-                $loadedTextDomain = $loader->load($locale, $filename);
-                if ($loadedTextDomain === null) {
-                    continue;
-                }
-
-                if (isset($this->messages[$textDomain][$locale])) {
-                    $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
-                } else {
-                    $this->messages[$textDomain][$locale] = $loadedTextDomain;
-                }
+                $this->insertLoadedTextDomain(
+                    $loader->load($locale, $filename),
+                    $textDomain,
+                    $locale,
+                );
 
                 $messagesLoaded = true;
             }
@@ -688,28 +674,23 @@ class Translator implements TranslatorInterface
     {
         $messagesLoaded = false;
 
-        foreach ([$locale, '*'] as $currentLocale) {
+        foreach ([$locale, self::ANY_LOCALE] as $currentLocale) {
             if (! isset($this->files[$textDomain][$currentLocale])) {
                 continue;
             }
 
             foreach ($this->files[$textDomain][$currentLocale] as $file) {
-                $loader = $this->pluginManager->get($file['type']);
+                $loader = $this->pluginManager->get($file->type);
 
                 if (! $loader instanceof FileLoaderInterface) {
                     throw new Exception\RuntimeException('Specified loader is not a file loader');
                 }
 
-                $loadedTextDomain = $loader->load($locale, $file['filename']);
-                if ($loadedTextDomain === null) {
-                    continue;
-                }
-
-                if (isset($this->messages[$textDomain][$locale])) {
-                    $this->messages[$textDomain][$locale]->merge($loadedTextDomain);
-                } else {
-                    $this->messages[$textDomain][$locale] = $loadedTextDomain;
-                }
+                $this->insertLoadedTextDomain(
+                    $loader->load($locale, $file->filename),
+                    $textDomain,
+                    $locale,
+                );
 
                 $messagesLoaded = true;
             }
@@ -718,6 +699,29 @@ class Translator implements TranslatorInterface
         }
 
         return $messagesLoaded;
+    }
+
+    /**
+     * @param non-empty-string $textDomain
+     * @param non-empty-string $locale
+     */
+    private function insertLoadedTextDomain(TextDomain|null $data, string $textDomain, string $locale): void
+    {
+        $this->messages[$textDomain] ??= [];
+
+        if ($data === null) {
+            $this->messages[$textDomain][$locale] ??= null;
+
+            return;
+        }
+
+        if (isset($this->messages[$textDomain][$locale])) {
+            $this->messages[$textDomain][$locale]->merge($data);
+
+            return;
+        }
+
+        $this->messages[$textDomain][$locale] = $data;
     }
 
     /**

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -86,23 +86,25 @@ class Translator implements TranslatorInterface
 
     private CacheItemPoolInterface|null $cache = null;
 
-    /**
-     * Event manager for triggering translator events.
-     *
-     * @var EventManagerInterface
-     */
-    protected $events;
-
-    /**
-     * Whether events are enabled
-     *
-     * @var bool
-     */
-    protected $eventsEnabled = false;
+    private readonly EventManagerInterface $events;
+    private bool $eventsEnabled = false;
 
     public function __construct(
         private readonly LoaderPluginManagerInterface $pluginManager,
+        EventManagerInterface|null $eventManager = null,
     ) {
+        // When an EventManager is supplied to the constructor, enable events. The user clearly wants them!
+        if ($eventManager !== null) {
+            $this->eventsEnabled = true;
+        }
+
+        $eventManager ??= new EventManager();
+        $eventManager->setIdentifiers([
+            self::class,
+            'translator',
+        ]);
+
+        $this->events = $eventManager;
     }
 
     /**
@@ -716,42 +718,15 @@ class Translator implements TranslatorInterface
         return $this->messages[$textDomain][$locale];
     }
 
-    /**
-     * Get the event manager.
-     *
-     * @return EventManagerInterface
-     */
-    public function getEventManager()
+    public function getEventManager(): EventManagerInterface
     {
-        if (! $this->events instanceof EventManagerInterface) {
-            $this->setEventManager(new EventManager());
-        }
-
         return $this->events;
     }
 
     /**
-     * Set the event manager instance used by this translator.
-     *
-     * @return $this
-     */
-    public function setEventManager(EventManagerInterface $events)
-    {
-        $events->setIdentifiers([
-            self::class,
-            static::class,
-            'translator',
-        ]);
-        $this->events = $events;
-        return $this;
-    }
-
-    /**
      * Check whether the event manager is enabled.
-     *
-     * @return bool
      */
-    public function isEventManagerEnabled()
+    public function isEventManagerEnabled(): bool
     {
         return $this->eventsEnabled;
     }
@@ -761,7 +736,7 @@ class Translator implements TranslatorInterface
      *
      * @return $this
      */
-    public function enableEventManager()
+    public function enableEventManager(): self
     {
         $this->eventsEnabled = true;
         return $this;
@@ -772,7 +747,7 @@ class Translator implements TranslatorInterface
      *
      * @return $this
      */
-    public function disableEventManager()
+    public function disableEventManager(): self
     {
         $this->eventsEnabled = false;
         return $this;

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -99,7 +99,7 @@ class Translator implements TranslatorInterface
     private bool $eventsEnabled = false;
 
     public function __construct(
-        private readonly LoaderPluginManagerInterface $pluginManager,
+        private readonly MessageLoaderPluginManagerInterface $pluginManager,
         EventManagerInterface|null $eventManager = null,
     ) {
         // When an EventManager is supplied to the constructor, enable events. The user clearly wants them!
@@ -123,7 +123,7 @@ class Translator implements TranslatorInterface
      * @return static
      * @throws Exception\InvalidArgumentException
      */
-    public static function factory(LoaderPluginManagerInterface $pluginManager, $options)
+    public static function factory(MessageLoaderPluginManagerInterface $pluginManager, $options)
     {
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -345,7 +345,7 @@ class Translator implements TranslatorInterface
 
         $index = $number === 1 ? 0 : 1; // en_EN Plural rule
         if ($this->messages[$textDomain][$locale] instanceof TextDomain) {
-            $index = (int) $this->messages[$textDomain][$locale]
+            $index = $this->messages[$textDomain][$locale]
                 ->getPluralRule()->evaluate($number);
         }
 

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -101,7 +101,7 @@ class Translator implements TranslatorInterface
     protected $eventsEnabled = false;
 
     public function __construct(
-        private LoaderPluginManager $pluginManager,
+        private readonly LoaderPluginManagerInterface $pluginManager,
     ) {
     }
 
@@ -112,7 +112,7 @@ class Translator implements TranslatorInterface
      * @return static
      * @throws Exception\InvalidArgumentException
      */
-    public static function factory(LoaderPluginManager $pluginManager, $options)
+    public static function factory(LoaderPluginManagerInterface $pluginManager, $options)
     {
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -18,6 +18,6 @@ final readonly class TranslatorServiceFactory implements FactoryInterface
         $config   = $container->get('config');
         $trConfig = $config['translator'] ?? [];
 
-        return Translator::factory($container->get(LoaderPluginManagerInterface::class), $trConfig);
+        return Translator::factory($container->get(MessageLoaderPluginManagerInterface::class), $trConfig);
     }
 }

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -15,12 +15,9 @@ final readonly class TranslatorServiceFactory implements FactoryInterface
         ?array $options = null,
     ): Translator {
         // Configure the translator
-        $config     = $container->get('config');
-        $trConfig   = $config['translator'] ?? [];
-        $translator = Translator::factory($trConfig);
-        if ($container->has('TranslatorPluginManager')) {
-            $translator->setPluginManager($container->get('TranslatorPluginManager'));
-        }
-        return $translator;
+        $config   = $container->get('config');
+        $trConfig = $config['translator'] ?? [];
+
+        return Translator::factory($container->get(LoaderPluginManager::class), $trConfig);
     }
 }

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -18,6 +18,6 @@ final readonly class TranslatorServiceFactory implements FactoryInterface
         $config   = $container->get('config');
         $trConfig = $config['translator'] ?? [];
 
-        return Translator::factory($container->get(LoaderPluginManager::class), $trConfig);
+        return Translator::factory($container->get(LoaderPluginManagerInterface::class), $trConfig);
     }
 }

--- a/src/Translator/Value/TranslationFile.php
+++ b/src/Translator/Value/TranslationFile.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Translator\Value;
+
+use Laminas\I18n\Exception\InvalidArgumentException;
+use Laminas\I18n\Translator\Loader\FileLoaderInterface;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-internal Laminas
+ * @psalm-internal LaminasTest
+ */
+final readonly class TranslationFile
+{
+    /**
+     * @param non-empty-string|class-string<FileLoaderInterface> $type The type of file loader that should be used
+     *                                                                 to load this file
+     * @param non-empty-string $filename
+     * @param non-empty-string $locale
+     * @param non-empty-string $textDomain
+     */
+    public function __construct(
+        public string $type,
+        public string $filename,
+        public string $locale,
+        public string $textDomain,
+    ) {
+    }
+
+    /**
+     * @param array<array-key, mixed> $spec
+     * @param non-empty-string $defaultLocale
+     * @param non-empty-string $defaultTextDomain
+     */
+    public static function fromArray(array $spec, string $defaultLocale, string $defaultTextDomain): self
+    {
+        return new self(
+            self::assertKey($spec['type'] ?? null, 'type'),
+            self::assertKey($spec['filename'] ?? null, 'filename'),
+            self::assertKey($spec['locale'] ?? $defaultLocale, 'locale'),
+            self::assertKey($spec['text_domain'] ?? $defaultTextDomain, 'text_domain'),
+        );
+    }
+
+    /** @return non-empty-string */
+    private static function assertKey(mixed $value, string $key): string
+    {
+        if (! is_string($value) || $value === '') {
+            throw new InvalidArgumentException(sprintf(
+                'The key "%s" must be set and should contain a non-empty string',
+                $key,
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/src/Translator/Value/TranslatorFilePattern.php
+++ b/src/Translator/Value/TranslatorFilePattern.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Translator\Value;
+
+use Laminas\I18n\Exception\InvalidArgumentException;
+use Laminas\I18n\Translator\Loader\FileLoaderInterface;
+
+use function is_dir;
+use function is_readable;
+use function is_string;
+use function realpath;
+use function rtrim;
+use function sprintf;
+use function substr_count;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * @internal
+ *
+ * @psalm-internal Laminas
+ * @psalm-internal LaminasTest
+ */
+final readonly class TranslatorFilePattern
+{
+    /** @var non-empty-string */
+    public string $baseDirectory;
+
+    /**
+     * @param non-empty-string|class-string<FileLoaderInterface> $type A value that can be used to retrieve the
+     *                                                                 correct file loader from the plugin manager.
+     * @param non-empty-string $baseDirectory                          A readable directory on-disk containing the
+     *                                                                 translation files.
+     * @param non-empty-string $pattern                                A sprintf pattern with one placeholder that
+     *                                                                 will be replaced with the desired locale.
+     * @param non-empty-string $textDomain                             The text domain the files are associated with.
+     */
+    public function __construct(
+        public string $type,
+        string $baseDirectory,
+        public string $pattern,
+        public string $textDomain,
+    ) {
+        $directory = realpath(rtrim($baseDirectory, DIRECTORY_SEPARATOR));
+
+        if (! is_string($directory) || $directory === '' || ! is_dir($directory) || ! is_readable($directory)) {
+            throw new InvalidArgumentException(sprintf(
+                'The base directory must be a readable directory on the local filesystem. Received "%s"',
+                $baseDirectory,
+            ));
+        }
+
+        $this->baseDirectory = $directory;
+
+        if (substr_count($this->pattern, '%s') !== 1) {
+            throw new InvalidArgumentException(sprintf(
+                'File name patterns should contain exactly one placeholder "%%s" to receive the locale. Received "%s"',
+                $this->pattern,
+            ));
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $spec
+     * @param non-empty-string $defaultTextDomain
+     */
+    public static function fromArray(array $spec, string $defaultTextDomain): self
+    {
+        return new self(
+            self::assertKey($spec['type'] ?? null, 'type'),
+            self::assertKey($spec['base_dir'] ?? null, 'base_dir'),
+            self::assertKey($spec['pattern'] ?? null, 'pattern'),
+            self::assertKey($spec['text_domain'] ?? $defaultTextDomain, 'text_domain'),
+        );
+    }
+
+    /** @return non-empty-string */
+    private static function assertKey(mixed $value, string $key): string
+    {
+        if (! is_string($value) || $value === '') {
+            throw new InvalidArgumentException(sprintf(
+                'The key "%s" must be set and should contain a non-empty string',
+                $key,
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/test/Translator/Loader/GettextTest.php
+++ b/test/Translator/Loader/GettextTest.php
@@ -74,6 +74,7 @@ final class GettextTest extends TestCase
     {
         $loader     = new GettextLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.mo');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -83,6 +84,7 @@ final class GettextTest extends TestCase
     {
         $loader     = new GettextLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.mo');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals(2, $textDomain->getPluralRule()->evaluate(0));
         self::assertEquals(0, $textDomain->getPluralRule()->evaluate(1));
@@ -95,6 +97,7 @@ final class GettextTest extends TestCase
         $loader = new GettextLoader();
         $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'translation_en.mo');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -105,6 +108,7 @@ final class GettextTest extends TestCase
         $loader = new GettextLoader();
         $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'phar://' . $this->testFilesDir . '/translations.phar/translation_en.mo');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -117,6 +121,7 @@ final class GettextTest extends TestCase
         $loader->setUseIncludePath(true);
 
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.mo');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals(
             [

--- a/test/Translator/Loader/IniTest.php
+++ b/test/Translator/Loader/IniTest.php
@@ -72,6 +72,7 @@ final class IniTest extends TestCase
     {
         $loader     = new IniLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.ini');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -81,6 +82,7 @@ final class IniTest extends TestCase
     {
         $loader     = new IniLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en_without_plural.ini');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -90,6 +92,7 @@ final class IniTest extends TestCase
     {
         $loader     = new IniLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en_simple_syntax.ini');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -99,6 +102,7 @@ final class IniTest extends TestCase
     {
         $loader     = new IniLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.ini');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         $rule = $textDomain->getPluralRule();
         self::assertInstanceOf(Rule::class, $rule);

--- a/test/Translator/Loader/PhpArrayTest.php
+++ b/test/Translator/Loader/PhpArrayTest.php
@@ -66,6 +66,7 @@ final class PhpArrayTest extends TestCase
     {
         $loader     = new PhpArrayLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.php');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -75,6 +76,7 @@ final class PhpArrayTest extends TestCase
     {
         $loader     = new PhpArrayLoader();
         $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.php');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals(2, $textDomain->getPluralRule()->evaluate(0));
         self::assertEquals(0, $textDomain->getPluralRule()->evaluate(1));
@@ -87,6 +89,7 @@ final class PhpArrayTest extends TestCase
         $loader = new PhpArrayLoader();
         $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'translation_en.php');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -97,6 +100,7 @@ final class PhpArrayTest extends TestCase
         $loader = new PhpArrayLoader();
         $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'phar://' . $this->testFilesDir . '/translations.phar/translation_en.php');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);

--- a/test/Translator/Loader/PhpMemoryArrayTest.php
+++ b/test/Translator/Loader/PhpMemoryArrayTest.php
@@ -26,14 +26,6 @@ final class PhpMemoryArrayTest extends TestCase
         $this->testFilesDir = $realpath;
     }
 
-    public function testLoaderFailsToLoadNonArray(): void
-    {
-        $loader = new PhpMemoryArrayLoader('foo');
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected an array, but received');
-        $loader->load('en_US', 'default');
-    }
-
     public function testLoaderFailsToLoadMissingTextDomain(): void
     {
         $loader = new PhpMemoryArrayLoader([]);
@@ -61,6 +53,7 @@ final class PhpMemoryArrayTest extends TestCase
     {
         $loader     = new PhpMemoryArrayLoader(include $this->testFilesDir . '/translation_en.php');
         $textDomain = $loader->load('en_US', 'default');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals('Message 1 (en)', $textDomain['Message 1']);
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
@@ -70,6 +63,7 @@ final class PhpMemoryArrayTest extends TestCase
     {
         $loader     = new PhpMemoryArrayLoader(include $this->testFilesDir . '/translation_en.php');
         $textDomain = $loader->load('en_US', 'default');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
 
         self::assertEquals(2, $textDomain->getPluralRule()->evaluate(0));
         self::assertEquals(0, $textDomain->getPluralRule()->evaluate(1));

--- a/test/Translator/TestAsset/Loader.php
+++ b/test/Translator/TestAsset/Loader.php
@@ -11,16 +11,7 @@ final class Loader implements FileLoaderInterface
 {
     public ?TextDomain $textDomain = null;
 
-    /**
-     * load(): defined by LoaderInterface.
-     *
-     * @see    LoaderInterface::load()
-     *
-     * @param  string $filename
-     * @param  string $locale
-     * @return TextDomain|null
-     */
-    public function load($filename, $locale)
+    public function load(string $locale, string $filename): TextDomain|null
     {
         return $this->textDomain;
     }

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\I18n\Translator;
 
-use Laminas\I18n\Translator\LoaderPluginManager;
+use Laminas\I18n\Translator\LoaderPluginManagerInterface;
 use Laminas\I18n\Translator\Translator;
 use Laminas\I18n\Translator\TranslatorServiceFactory;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
@@ -16,14 +16,14 @@ final class TranslatorServiceFactoryTest extends TestCase
 {
     public function testCreateServiceWithNoTranslatorKeyDefined(): void
     {
-        $pluginManager = new LoaderPluginManager(new ServiceManager());
+        $pluginManager = self::createStub(LoaderPluginManagerInterface::class);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects(self::exactly(2))
             ->method('get')
             ->willReturnMap([
                 ['config', []],
-                [LoaderPluginManager::class, $pluginManager],
+                [LoaderPluginManagerInterface::class, $pluginManager],
             ]);
 
         $factory    = new TranslatorServiceFactory();

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\I18n\Translator;
 use Laminas\I18n\Translator\LoaderPluginManager;
 use Laminas\I18n\Translator\Translator;
 use Laminas\I18n\Translator\TranslatorServiceFactory;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceManager;
 use LaminasTest\I18n\TestCase;
 use Psr\Container\ContainerInterface;
@@ -15,42 +16,32 @@ final class TranslatorServiceFactoryTest extends TestCase
 {
     public function testCreateServiceWithNoTranslatorKeyDefined(): void
     {
-        $pluginManagerMock = new LoaderPluginManager(new ServiceManager());
+        $pluginManager = new LoaderPluginManager(new ServiceManager());
 
-        $serviceLocator = $this->createMock(ContainerInterface::class);
-        $serviceLocator->expects(self::once())
-            ->method('has')
-            ->with('TranslatorPluginManager')
-            ->willReturn(true);
-
-        $serviceLocator->expects(self::exactly(2))
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::exactly(2))
             ->method('get')
             ->willReturnMap([
-                ['TranslatorPluginManager', $pluginManagerMock],
                 ['config', []],
+                [LoaderPluginManager::class, $pluginManager],
             ]);
 
         $factory    = new TranslatorServiceFactory();
-        $translator = $factory($serviceLocator, Translator::class);
+        $translator = $factory($container, Translator::class);
         self::assertInstanceOf(Translator::class, $translator);
-        self::assertSame($pluginManagerMock, $translator->getPluginManager());
     }
 
     public function testCreateServiceWithNoTranslatorPluginManagerDefined(): void
     {
-        $serviceLocator = $this->createMock(ContainerInterface::class);
-        $serviceLocator->expects(self::once())
-            ->method('has')
-            ->with('TranslatorPluginManager')
-            ->willReturn(false);
+        $serviceManager = new ServiceManager([
+            'services' => [
+                'config' => [],
+            ],
+        ]);
 
-        $serviceLocator->expects(self::once())
-            ->method('get')
-            ->with('config')
-            ->willReturn([]);
+        $factory = new TranslatorServiceFactory();
+        $this->expectException(ServiceNotFoundException::class);
 
-        $factory    = new TranslatorServiceFactory();
-        $translator = $factory($serviceLocator, Translator::class);
-        self::assertInstanceOf(Translator::class, $translator);
+        $factory->__invoke($serviceManager, 'whatever', []);
     }
 }

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\I18n\Translator;
 
-use Laminas\I18n\Translator\LoaderPluginManagerInterface;
+use Laminas\I18n\Translator\MessageLoaderPluginManagerInterface;
 use Laminas\I18n\Translator\Translator;
 use Laminas\I18n\Translator\TranslatorServiceFactory;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
@@ -16,14 +16,14 @@ final class TranslatorServiceFactoryTest extends TestCase
 {
     public function testCreateServiceWithNoTranslatorKeyDefined(): void
     {
-        $pluginManager = self::createStub(LoaderPluginManagerInterface::class);
+        $pluginManager = self::createStub(MessageLoaderPluginManagerInterface::class);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects(self::exactly(2))
             ->method('get')
             ->willReturnMap([
                 ['config', []],
-                [LoaderPluginManagerInterface::class, $pluginManager],
+                [MessageLoaderPluginManagerInterface::class, $pluginManager],
             ]);
 
         $factory    = new TranslatorServiceFactory();

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -559,20 +559,6 @@ final class TranslatorTest extends TestCase
         self::assertNull($allMessages);
     }
 
-    public function testNullMessageArgumentShouldReturnAnEmptyString(): void
-    {
-        $loader             = new TestLoader();
-        $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $this->pluginManager->configure([
-            'services' => [
-                'test' => $loader,
-            ],
-        ]);
-        $this->translator->addTranslationFile('test', null);
-
-        self::assertEquals('', $this->translator->translate(null));
-    }
-
     public function testTranslateWithEmptyStringLocale(): void
     {
         $this->translator->setLocale('en_US');

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -166,7 +166,7 @@ final class TranslatorTest extends TestCase
                 'test' => $loader,
             ],
         ]);
-        $this->translator->addTranslationFile('test', null);
+        $this->translator->addTranslationFile('test', 'anything');
 
         self::assertEquals('bar', $this->translator->translate('foo'));
     }
@@ -191,7 +191,7 @@ final class TranslatorTest extends TestCase
         $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
         $this->pluginManager->configure(['services' => ['test' => $loader]]);
-        $this->translator->addTranslationFile('test', null);
+        $this->translator->addTranslationFile('test', 'anything');
 
         self::assertEquals('bar', $this->translator->translate('foo'));
 
@@ -583,6 +583,6 @@ final class TranslatorTest extends TestCase
             'en_US',
         );
 
-        self::assertEquals('Message 8 (en)', $this->translator->translate('Message 8', 'default', ''));
+        self::assertEquals('Message 8 (en)', $this->translator->translate('Message 8'));
     }
 }

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -8,6 +8,7 @@ use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
 use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
+use Laminas\EventManager\EventManager;
 use Laminas\I18n\Translator\LoaderPluginManager;
 use Laminas\I18n\Translator\TextDomain;
 use Laminas\I18n\Translator\Translator;
@@ -78,27 +79,27 @@ final class TranslatorTest extends TestCase
         //Test translations
         self::assertEquals(
             'Nachricht 1',
-            $translator->translate('Message 1')
+            $translator->translate('Message 1'),
         ); //translation-de_DE.php
         self::assertEquals(
             'Nachricht 9',
-            $translator->translate('Message 9')
+            $translator->translate('Message 9'),
         ); //translation-more-de_DE.php
         self::assertEquals(
             'Nachricht 10 - 0',
-            $translator->translatePlural('Message 10', 'Message 10', 1)
+            $translator->translatePlural('Message 10', 'Message 10', 1),
         ); //translation-de_DE.php
         self::assertEquals(
             'Nachricht 10 - 1',
-            $translator->translatePlural('Message 10', 'Message 10', 2)
+            $translator->translatePlural('Message 10', 'Message 10', 2),
         ); //translation-de_DE.php
         self::assertEquals(
             'Nachricht 11 - 0',
-            $translator->translatePlural('Message 11', 'Message 11', 1)
+            $translator->translatePlural('Message 11', 'Message 11', 1),
         ); //translation-more-de_DE.php
         self::assertEquals(
             'Nachricht 11 - 1',
-            $translator->translatePlural('Message 11', 'Message 11', 2)
+            $translator->translatePlural('Message 11', 'Message 11', 2),
         ); //translation-more-de_DE.php
     }
 
@@ -230,7 +231,7 @@ final class TranslatorTest extends TestCase
             'phparray',
             $this->testFilesDir . '/translation_en.php',
             'default',
-            'en_EN'
+            'en_EN',
         );
 
         $pl0 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 1);
@@ -247,7 +248,7 @@ final class TranslatorTest extends TestCase
         $this->translator->addTranslationFilePattern(
             'phparray',
             $this->testFilesDir . '/testarray',
-            'translation-%s.php'
+            'translation-%s.php',
         );
 
         $this->translator->setLocale('es_ES');
@@ -266,7 +267,7 @@ final class TranslatorTest extends TestCase
         $this->translator->addTranslationFilePattern(
             'phparray',
             $this->testFilesDir . '/testarray',
-            'translation-%s.php'
+            'translation-%s.php',
         );
 
         $this->translator->setLocale('de_DE');
@@ -288,7 +289,7 @@ final class TranslatorTest extends TestCase
             'phparray',
             $this->testFilesDir . '/testarray/translation-noplural-ja_JP.php',
             'default',
-            'ja_JP'
+            'ja_JP',
         );
 
         $pl0 = $this->translator->translatePlural('Message 9', 'Message 9 Plural', 1);
@@ -305,7 +306,7 @@ final class TranslatorTest extends TestCase
         $this->translator->addTranslationFilePattern(
             'phparray',
             $this->testFilesDir . '/testarray',
-            'translation-%s.php'
+            'translation-%s.php',
         );
 
         // Test that a locale without translations does not cause warnings
@@ -326,7 +327,7 @@ final class TranslatorTest extends TestCase
         $this->translator->addTranslationFilePattern(
             'phparray',
             $this->testFilesDir . '/testarray',
-            'translation-%s.php'
+            'translation-%s.php',
         );
 
         // Test that a locale without translations does not cause warnings
@@ -365,11 +366,9 @@ final class TranslatorTest extends TestCase
         $this->translator->enableEventManager();
         $this->translator->getEventManager()->attach(
             Translator::EVENT_MISSING_TRANSLATION,
-            // @codingStandardsIgnoreStart Generic.WhiteSpace.ScopeIndent.IncorrectExact
             static function (EventInterface $event) use (&$actualEvent) {
                 $actualEvent = $event;
-            }
-            // @codingStandardsIgnoreEnd
+            },
         );
 
         $this->translator->translate('foo', 'bar', 'baz');
@@ -381,7 +380,7 @@ final class TranslatorTest extends TestCase
                 'locale'      => 'baz',
                 'text_domain' => 'bar',
             ],
-            $actualEvent->getParams()
+            $actualEvent->getParams(),
         );
 
         // But fire no event when disabled
@@ -389,6 +388,38 @@ final class TranslatorTest extends TestCase
         $this->translator->disableEventManager();
         $this->translator->translate('foo', 'bar', 'baz');
         self::assertNull($actualEvent);
+    }
+
+    public function testUsersCanSupplyASpecificEventManagerInstance(): void
+    {
+        $actualEvent  = null;
+        $eventManager = new EventManager();
+        $eventManager->attach(
+            Translator::EVENT_MISSING_TRANSLATION,
+            static function (EventInterface $event) use (&$actualEvent) {
+                $actualEvent = $event;
+            },
+        );
+
+        $translator = new Translator(
+            new LoaderPluginManager(new ServiceManager()),
+            $eventManager,
+        );
+
+        self::assertSame($eventManager, $translator->getEventManager());
+        self::assertTrue($translator->isEventManagerEnabled());
+
+        $translator->translate('foo', 'bar', 'baz');
+
+        self::assertInstanceOf(Event::class, $actualEvent);
+        self::assertEquals(
+            [
+                'message'     => 'foo',
+                'locale'      => 'baz',
+                'text_domain' => 'bar',
+            ],
+            $actualEvent->getParams(),
+        );
     }
 
     public function testListenerOnMissingTranslationEventCanReturnString(): void
@@ -402,17 +433,17 @@ final class TranslatorTest extends TestCase
             Translator::EVENT_MISSING_TRANSLATION,
             static function () use (&$trigger) {
                 $trigger = true;
-            }
+            },
         );
         $events->attach(
             Translator::EVENT_MISSING_TRANSLATION,
-            static fn() => 'EVENT TRIGGERED'
+            static fn() => 'EVENT TRIGGERED',
         );
         $events->attach(
             Translator::EVENT_MISSING_TRANSLATION,
             static function () use (&$doNotTrigger) {
                 $doNotTrigger = true;
-            }
+            },
         );
 
         $result = $this->translator->translate('foo', 'bar', 'baz');
@@ -440,7 +471,7 @@ final class TranslatorTest extends TestCase
                 'locale'      => 'baz',
                 'text_domain' => 'bar',
             ],
-            $actualEvent->getParams()
+            $actualEvent->getParams(),
         );
 
         // But fire no event when disabled
@@ -464,17 +495,17 @@ final class TranslatorTest extends TestCase
             Translator::EVENT_NO_MESSAGES_LOADED,
             static function () use (&$trigger): void {
                 $trigger = true;
-            }
+            },
         );
         $events->attach(
             Translator::EVENT_NO_MESSAGES_LOADED,
-            static fn() => $textDomain
+            static fn() => $textDomain,
         );
         $events->attach(
             Translator::EVENT_NO_MESSAGES_LOADED,
             static function () use (&$doNotTrigger) {
                 $doNotTrigger = true;
-            }
+            },
         );
 
         $result = $this->translator->translate('foo', 'bar', 'baz');
@@ -491,7 +522,7 @@ final class TranslatorTest extends TestCase
             'phparray',
             $this->testFilesDir . '/translation_en.php',
             'default',
-            'en_EN'
+            'en_EN',
         );
 
         $allMessages = $this->translator->getAllMessages();
@@ -507,7 +538,7 @@ final class TranslatorTest extends TestCase
             'phparray',
             $this->testFilesDir . '/translation_en.php',
             'default',
-            'en_EN'
+            'en_EN',
         );
 
         $allMessages = $this->translator->getAllMessages('foo_domain');
@@ -521,7 +552,7 @@ final class TranslatorTest extends TestCase
             'phparray',
             $this->testFilesDir . '/translation_en.php',
             'default',
-            'en_EN'
+            'en_EN',
         );
 
         $allMessages = $this->translator->getAllMessages('default', 'es_ES');
@@ -549,7 +580,7 @@ final class TranslatorTest extends TestCase
             'phparray',
             $this->testFilesDir . '/testarray/translation-more-en_US.php',
             'default',
-            'en_US'
+            'en_US',
         );
 
         self::assertEquals('Message 8 (en)', $this->translator->translate('Message 8', 'default', ''));

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -8,8 +8,10 @@ use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
 use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
+use Laminas\I18n\Translator\LoaderPluginManager;
 use Laminas\I18n\Translator\TextDomain;
 use Laminas\I18n\Translator\Translator;
+use Laminas\ServiceManager\ServiceManager;
 use LaminasTest\I18n\TestCase;
 use LaminasTest\I18n\Translator\TestAsset\Loader as TestLoader;
 use Locale;
@@ -18,18 +20,20 @@ final class TranslatorTest extends TestCase
 {
     private Translator $translator;
     private string $testFilesDir;
+    private LoaderPluginManager $pluginManager;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->translator = new Translator();
+        $this->pluginManager = new LoaderPluginManager(new ServiceManager());
+        $this->translator    = new Translator($this->pluginManager);
         Locale::setDefault('en_EN');
         $this->testFilesDir = __DIR__ . '/_files';
     }
 
     public function testFactoryCreatesTranslator(): void
     {
-        $translator = Translator::factory([
+        $translator = Translator::factory($this->pluginManager, [
             'locale'   => 'de_DE',
             'patterns' => [
                 [
@@ -52,7 +56,7 @@ final class TranslatorTest extends TestCase
 
     public function testTranslationFromSeveralTranslationFiles(): void
     {
-        $translator = Translator::factory([
+        $translator = Translator::factory($this->pluginManager, [
             'locale'                    => 'de_DE',
             'translation_file_patterns' => [
                 [
@@ -100,7 +104,7 @@ final class TranslatorTest extends TestCase
 
     public function testTranslationFromDifferentSourceTypes(): void
     {
-        $translator = Translator::factory([
+        $translator = Translator::factory($this->pluginManager, [
             'locale'                    => 'de_DE',
             'translation_file_patterns' => [
                 [
@@ -125,7 +129,7 @@ final class TranslatorTest extends TestCase
     {
         $cacheItemPool = new CacheItemPoolDecorator(new Memory());
 
-        $translator = Translator::factory([
+        $translator = Translator::factory($this->pluginManager, [
             'locale'   => 'de_DE',
             'patterns' => [
                 [
@@ -156,13 +160,11 @@ final class TranslatorTest extends TestCase
     {
         $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $pm                 = $this->translator->getPluginManager();
-        $pm->configure([
+        $this->pluginManager->configure([
             'services' => [
                 'test' => $loader,
             ],
         ]);
-        $this->translator->setPluginManager($pm);
         $this->translator->addTranslationFile('test', null);
 
         self::assertEquals('bar', $this->translator->translate('foo'));
@@ -187,9 +189,7 @@ final class TranslatorTest extends TestCase
 
         $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $plugins            = $this->translator->getPluginManager();
-        $plugins->configure(['services' => ['test' => $loader]]);
-        $this->translator->setPluginManager($plugins);
+        $this->pluginManager->configure(['services' => ['test' => $loader]]);
         $this->translator->addTranslationFile('test', null);
 
         self::assertEquals('bar', $this->translator->translate('foo'));
@@ -349,12 +349,12 @@ final class TranslatorTest extends TestCase
 
     public function testEnableEventMangerViaFactory(): void
     {
-        $translator = Translator::factory([
+        $translator = Translator::factory($this->pluginManager, [
             'event_manager_enabled' => true,
         ]);
         self::assertTrue($translator->isEventManagerEnabled());
 
-        $translator = Translator::factory([]);
+        $translator = Translator::factory($this->pluginManager, []);
         self::assertFalse($translator->isEventManagerEnabled());
     }
 
@@ -532,13 +532,11 @@ final class TranslatorTest extends TestCase
     {
         $loader             = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $pm                 = $this->translator->getPluginManager();
-        $pm->configure([
+        $this->pluginManager->configure([
             'services' => [
                 'test' => $loader,
             ],
         ]);
-        $this->translator->setPluginManager($pm);
         $this->translator->addTranslationFile('test', null);
 
         self::assertEquals('', $this->translator->translate(null));

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -111,7 +111,7 @@ final class TranslatorTest extends TestCase
                 [
                     'type'     => 'phparray',
                     'base_dir' => $this->testFilesDir . '/testarray',
-                    'pattern'  => 'translation-de_DE.php',
+                    'pattern'  => 'translation-%s.php',
                 ],
             ],
             'translation_files'         => [

--- a/test/Translator/Value/TranslationFileTest.php
+++ b/test/Translator/Value/TranslationFileTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\i18n\Translator\Value;
+
+use Laminas\I18n\Exception\InvalidArgumentException;
+use Laminas\I18n\Translator\Value\TranslationFile;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+final class TranslationFileTest extends TestCase
+{
+    /**
+     * @return list<array{
+     *     0: mixed,
+     *     1: mixed,
+     *     2: mixed,
+     *     3: mixed,
+     *     4: string,
+     * }>
+     */
+    public static function invalidParamsProvider(): array
+    {
+        return [
+            [null, 'some-file.mo', 'en_GB', 'domain', 'type'],
+            ['', 'some-file.mo', 'en_GB', 'domain', 'type'],
+            [1, 'some-file.mo', 'en_GB', 'domain', 'type'],
+            ['foo', null, 'en_GB', 'domain', 'filename'],
+            ['foo', '', 'en_GB', 'domain', 'filename'],
+            ['foo', 1, 'en_GB', 'domain', 'filename'],
+            ['foo', 'some-file.mo', [], 'domain', 'locale'],
+            ['foo', 'some-file.mo', '', 'domain', 'locale'],
+            ['foo', 'some-file.mo', 1, 'domain', 'locale'],
+            ['foo', 'some-file.mo', 'en_GB', [], 'text_domain'],
+            ['foo', 'some-file.mo', 'en_GB', '', 'text_domain'],
+            ['foo', 'some-file.mo', 'en_GB', 1, 'text_domain'],
+        ];
+    }
+
+    #[DataProvider('invalidParamsProvider')]
+    public function testAllValuesMustBeNonEmptyString(
+        mixed $type,
+        mixed $filename,
+        mixed $locale,
+        mixed $textDomain,
+        string $invalidKey,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The key "%s" must be set and should contain a non-empty string',
+            $invalidKey,
+        ));
+
+        TranslationFile::fromArray([
+            'type'        => $type,
+            'filename'    => $filename,
+            'locale'      => $locale,
+            'text_domain' => $textDomain,
+        ], 'foo', 'bar');
+    }
+
+    public function testDefaultsAreUsedForMissingKeys(): void
+    {
+        $file = TranslationFile::fromArray([
+            'type'     => 'foo',
+            'filename' => 'bar',
+        ], 'baz', 'bat');
+
+        self::assertSame('foo', $file->type);
+        self::assertSame('bar', $file->filename);
+        self::assertSame('baz', $file->locale);
+        self::assertSame('bat', $file->textDomain);
+
+        $file = TranslationFile::fromArray([
+            'type'     => 'foo',
+            'filename' => 'bar',
+            'locale'   => 'en',
+        ], 'baz', 'bat');
+
+        self::assertSame('foo', $file->type);
+        self::assertSame('bar', $file->filename);
+        self::assertSame('en', $file->locale);
+        self::assertSame('bat', $file->textDomain);
+
+        $file = TranslationFile::fromArray([
+            'type'        => 'foo',
+            'filename'    => 'bar',
+            'text_domain' => 'bing',
+        ], 'baz', 'bat');
+
+        self::assertSame('foo', $file->type);
+        self::assertSame('bar', $file->filename);
+        self::assertSame('baz', $file->locale);
+        self::assertSame('bing', $file->textDomain);
+    }
+}

--- a/test/Translator/Value/TranslatorFilePatternTest.php
+++ b/test/Translator/Value/TranslatorFilePatternTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\i18n\Translator\Value;
+
+use Laminas\I18n\Exception\InvalidArgumentException;
+use Laminas\I18n\Translator\Value\TranslatorFilePattern;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+final class TranslatorFilePatternTest extends TestCase
+{
+    public function testANonExistingDirectoryIsExceptional(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The base directory must be a readable directory on the local filesystem.');
+
+        new TranslatorFilePattern(
+            'foo',
+            __DIR__ . '/not-there',
+            'foo-%s.txt',
+            'baz',
+        );
+    }
+
+    public function testTheFileNamePatternMustContainAPlaceholder(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'File name patterns should contain exactly one placeholder "%s" to receive the locale',
+        );
+
+        new TranslatorFilePattern(
+            'foo',
+            __DIR__,
+            'foo.txt',
+            'baz',
+        );
+    }
+
+    /**
+     * @return list<array{
+     *     0: mixed,
+     *     1: mixed,
+     *     2: mixed,
+     *     3: mixed,
+     *     4: string,
+     * }>
+     */
+    public static function invalidParamsProvider(): array
+    {
+        return [
+            [null, __DIR__, '%s.txt', 'domain', 'type'],
+            ['', __DIR__, '%s.txt', 'domain', 'type'],
+            [1, __DIR__, '%s.txt', 'domain', 'type'],
+            ['foo', null, '%s.txt', 'domain', 'base_dir'],
+            ['foo', '', '%s.txt', 'domain', 'base_dir'],
+            ['foo', 1, '%s.txt', 'domain', 'base_dir'],
+            ['foo', __DIR__, null, 'domain', 'pattern'],
+            ['foo', __DIR__, '', 'domain', 'pattern'],
+            ['foo', __DIR__, 1, 'domain', 'pattern'],
+            ['foo', __DIR__, '%s.txt', [], 'text_domain'],
+            ['foo', __DIR__, '%s.txt', '', 'text_domain'],
+            ['foo', __DIR__, '%s.txt', 1, 'text_domain'],
+        ];
+    }
+
+    #[DataProvider('invalidParamsProvider')]
+    public function testAllValuesMustBeNonEmptyString(
+        mixed $type,
+        mixed $directory,
+        mixed $pattern,
+        mixed $textDomain,
+        string $invalidKey,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The key "%s" must be set and should contain a non-empty string',
+            $invalidKey,
+        ));
+
+        TranslatorFilePattern::fromArray([
+            'type'        => $type,
+            'base_dir'    => $directory,
+            'pattern'     => $pattern,
+            'text_domain' => $textDomain,
+        ], 'foo');
+    }
+}

--- a/tools/crc/config.json
+++ b/tools/crc/config.json
@@ -1,7 +1,4 @@
 {
     "symbol-whitelist" : [
-        "Laminas\\EventManager\\Event",
-        "Laminas\\EventManager\\EventManager",
-        "Laminas\\EventManager\\EventManagerInterface"
     ]
 }


### PR DESCRIPTION
- Makes the loader manager a hard constructor dependency
- Add an interface for the loader manager so it can be stubbed/mocked/replaced
- Make the event manager an optional constructor dependency
- Document internal array shapes
- Add value objects to represent translation files and file patterns, improving type safety