### PR TITLE
Introduce `DefaultLocale` Value Object

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -43,6 +43,7 @@ final class ConfigProvider
                 Translator\Translator::class            => Translator\TranslatorServiceFactory::class,
                 Translator\LoaderPluginManager::class   => Translator\LoaderPluginManagerFactory::class,
                 Geography\DefaultCountryCodeList::class => Geography\DefaultCountryCodeListFactory::class,
+                DefaultLocale::class                    => Factory\DefaultLocaleFactory::class,
             ],
         ];
     }

--- a/src/DefaultLocale.php
+++ b/src/DefaultLocale.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n;
+
+use Stringable;
+
+final readonly class DefaultLocale implements Stringable
+{
+    /** @param non-empty-string $locale */
+    public function __construct(public string $locale)
+    {
+    }
+
+    /** @return non-empty-string */
+    public function __toString(): string
+    {
+        return $this->locale;
+    }
+}

--- a/src/Factory/DefaultLocaleFactory.php
+++ b/src/Factory/DefaultLocaleFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Factory;
+
+use Laminas\I18n\DefaultLocale;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Locale;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+use function is_iterable;
+use function is_string;
+use function iterator_to_array;
+
+/**
+ * @internal
+ *
+ * @psalm-internal Laminas\I18n
+ * @psalm-internal LaminasTest\I18n
+ */
+final readonly class DefaultLocaleFactory implements FactoryInterface
+{
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null,
+    ): DefaultLocale {
+        /** @psalm-var mixed $config */
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = is_iterable($config) ? iterator_to_array($config) : [];
+
+        /** @psalm-var mixed $locale */
+        $locale = $config['locale'] ?? null;
+        $locale = is_string($locale) && $locale !== '' ? $locale : Locale::getDefault();
+        assert($locale !== '');
+
+        return new DefaultLocale($locale);
+    }
+}

--- a/test/Factory/DefaultLocaleFactoryTest.php
+++ b/test/Factory/DefaultLocaleFactoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\i18n\Factory;
+
+use ArrayObject;
+use Laminas\I18n\Factory\DefaultLocaleFactory;
+use Laminas\ServiceManager\ServiceManager;
+use Locale;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+
+final class DefaultLocaleFactoryTest extends TestCase
+{
+    /** @return iterable<string, array{0: iterable|null, 1: string}> */
+    public static function configScenarios(): iterable
+    {
+        $system = Locale::getDefault();
+        foreach (['en_GB', 'de_DE', 'nl_NL', 'en_US'] as $locale) {
+            if ($locale === $system) {
+                continue;
+            }
+
+            break;
+        }
+
+        $values = [
+            'No config at all' => [null, $system],
+            'Empty config'     => [[], $system],
+            'Null value'       => [['locale' => null], $system],
+            'Empty string'     => [['locale' => ''], $system],
+            'Non-empty'        => [['locale' => $locale], $locale],
+        ];
+
+        yield from $values;
+
+        $iterables = array_map(
+            static function (array $args): array {
+                if ($args[0] === null) {
+                    return $args;
+                }
+
+                return [
+                    new ArrayObject($args[0]),
+                    $args[1],
+                ];
+            },
+            $values,
+        );
+
+        foreach ($iterables as $label => $args) {
+            yield $label . ' (Iterable)' => $args;
+        }
+    }
+
+    #[DataProvider('configScenarios')]
+    public function testALocaleIsReturnedInAllPossibleSituations(iterable|null $config, string $expectLocale): void
+    {
+        $config = $config === null ? [] : [
+            'services' => [
+                'config' => $config,
+            ],
+        ];
+
+        $container = new ServiceManager($config);
+
+        $factory = new DefaultLocaleFactory();
+        $result  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame($expectLocale, $result->locale);
+        self::assertSame($expectLocale, $result->__toString());
+    }
+}


### PR DESCRIPTION
We need a 'default' locale in many situations. It makes sense to locate this default in the main I18n library, but rather than put a string in DI, we have a simple, stringable value object.

The default is guaranteed by falling back on `Locale::getDefault()` in the factory for this value object.
