### PR TITLE
Introduce `I18nDefaults`

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -15,7 +15,14 @@ final class ConfigProvider
      *
      * @return array{
      *     dependencies: ServiceManagerConfiguration,
-     *     locale: string|null,
+     *     locale: non-empty-string|null,
+     *     timezone: non-empty-string|null,
+     *     laminas-i18n?: array{
+     *         defaultTimeZone?: non-empty-string|null,
+     *         defaultCurrency?: non-empty-string|null,
+     *         defaultTextDomain?: non-empty-string|null,
+     *         defaultCountry?: non-empty-string|null,
+     *     }
      * }
      */
     public function __invoke(): array
@@ -23,6 +30,7 @@ final class ConfigProvider
         return [
             'dependencies' => $this->getDependencyConfig(),
             'locale'       => null,
+            'timezone'     => null,
         ];
     }
 
@@ -44,6 +52,7 @@ final class ConfigProvider
                 Translator\LoaderPluginManager::class   => Translator\LoaderPluginManagerFactory::class,
                 Geography\DefaultCountryCodeList::class => Geography\DefaultCountryCodeListFactory::class,
                 DefaultLocale::class                    => Factory\DefaultLocaleFactory::class,
+                I18nDefaults::class                     => Factory\I18nDefaultsFactory::class,
             ],
         ];
     }

--- a/src/Factory/I18nDefaultsFactory.php
+++ b/src/Factory/I18nDefaultsFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Factory;
+
+use DateTimeZone;
+use Laminas\I18n\CountryCode;
+use Laminas\I18n\DefaultLocale;
+use Laminas\I18n\I18nDefaults;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Locale;
+use NumberFormatter;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+use function date_default_timezone_get;
+use function is_array;
+use function is_iterable;
+use function is_string;
+use function iterator_to_array;
+use function preg_match;
+
+final readonly class I18nDefaultsFactory implements FactoryInterface
+{
+    /** @psalm-suppress MixedAssignment */
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null,
+    ): I18nDefaults {
+        $locale = $container->get(DefaultLocale::class);
+
+        /** @psalm-var mixed $config */
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = is_iterable($config) ? iterator_to_array($config) : [];
+
+        $i18nDefaults = $config['laminas-i18n'] ?? [];
+        $i18nDefaults = is_array($i18nDefaults) ? $i18nDefaults : [];
+
+        /**
+         * Timezone has historically been at the top-level, but we'll look under the new top-level key too
+         */
+        $timezone = $config['timezone'] ?? null;
+        $timezone = $i18nDefaults['defaultTimeZone'] ?? $timezone;
+        $timezone = is_string($timezone) && $timezone !== '' ? $timezone : date_default_timezone_get();
+
+        $currency = $i18nDefaults['defaultCurrency'] ?? null;
+        $currency = ! is_string($currency) || $currency === ''
+            ? $this->determineCurrencyFromLocale($locale->locale)
+            : $currency;
+
+        $country = $i18nDefaults['defaultCountry'] ?? Locale::getRegion($locale->locale);
+        assert(is_string($country) && $country !== '');
+
+        $textDomain = $i18nDefaults['defaultTextDomain'] ?? null;
+        $textDomain = ! is_string($textDomain) || $textDomain === '' ? 'default' : $textDomain;
+
+        return new I18nDefaults(
+            new DateTimeZone($timezone),
+            $currency,
+            $textDomain,
+            $locale->locale,
+            CountryCode::fromString($country),
+        );
+    }
+
+    /** @return non-empty-string */
+    private function determineCurrencyFromLocale(string $locale): string
+    {
+        $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+        $formatter->setPattern('¤¤');
+        $format = $formatter->format(0);
+        preg_match('/([A-Z]{3})/', $format, $match);
+        $code = $match[1] ?? null;
+
+        assert(is_string($code) && $code !== '');
+
+        return $code;
+    }
+}

--- a/src/I18nDefaults.php
+++ b/src/I18nDefaults.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n;
+
+use DateTimeZone;
+
+final readonly class I18nDefaults
+{
+    /**
+     * @param non-empty-string $defaultCurrencyCode
+     * @param non-empty-string $defaultTextDomain
+     * @param non-empty-string $defaultLocale
+     */
+    public function __construct(
+        public DateTimeZone $defaultTimeZone,
+        public string $defaultCurrencyCode,
+        public string $defaultTextDomain,
+        public string $defaultLocale,
+        public CountryCode $defaultCountry,
+    ) {
+    }
+}

--- a/test/Factory/I18nDefaultsFactoryTest.php
+++ b/test/Factory/I18nDefaultsFactoryTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\i18n\Factory;
+
+use ArrayObject;
+use Laminas\I18n\ConfigProvider;
+use Laminas\I18n\Factory\I18nDefaultsFactory;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Traversable;
+
+use function array_replace_recursive;
+use function date_default_timezone_get;
+use function iterator_to_array;
+
+/** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
+final class I18nDefaultsFactoryTest extends TestCase
+{
+    /** @return list<array{0: string, 1: string, 2: string}> */
+    public static function localesAndDefaultDetectionsProvider(): array
+    {
+        return [
+            ['en_GB', 'GBP', 'GB'],
+            ['en_US', 'USD', 'US'],
+            ['sw_TZ', 'TZS', 'TZ'],
+            ['sw_ZA', 'ZAR', 'ZA'],
+            ['de_DE', 'EUR', 'DE'],
+            ['es_MX', 'MXN', 'MX'],
+            ['es_AR', 'ARS', 'AR'],
+            ['es_UY', 'UYU', 'UY'],
+            ['pt_BR', 'BRL', 'BR'],
+            ['pt_PT', 'EUR', 'PT'],
+        ];
+    }
+
+    #[DataProvider('localesAndDefaultDetectionsProvider')]
+    public function testCorrectCountryAndCurrencyIsDetectedFromConfiguredLocale(
+        string $locale,
+        string $expectCurrency,
+        string $expectCountry,
+    ): void {
+        $container = $this->containerWithConfig(['locale' => $locale]);
+        $factory   = new I18nDefaultsFactory();
+        $defaults  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame($locale, $defaults->defaultLocale);
+        self::assertSame($expectCurrency, $defaults->defaultCurrencyCode);
+        self::assertSame($expectCountry, $defaults->defaultCountry->toString());
+    }
+
+    /** @return iterable<string, array{0: iterable|null, 1: string}> */
+    public static function timezoneConfigScenarios(): iterable
+    {
+        $system = date_default_timezone_get();
+        $values = [
+            'No config at all'          => [null, $system],
+            'Empty config'              => [[], $system],
+            'Legacy Key: Null value'    => [['timezone' => null], $system],
+            'Legacy Key: Empty string'  => [['timezone' => ''], $system],
+            'Legacy Key: Non-empty'     => [['timezone' => 'Europe/London'], 'Europe/London'],
+            'New Key: Null Value'       => [['laminas-i18n' => ['defaultTimeZone' => null]], $system],
+            'New Key: Empty String'     => [['laminas-i18n' => ['defaultTimeZone' => '']], $system],
+            'New Key: Not Empty'        => [
+                [
+                    'laminas-i18n' => ['defaultTimeZone' => 'Australia/Adelaide'],
+                ],
+                'Australia/Adelaide',
+            ],
+            'New Key overrides old key' => [
+                [
+                    'timezone'     => 'Africa/Johannesburg',
+                    'laminas-i18n' => ['defaultTimeZone' => 'Australia/Adelaide'],
+                ],
+                'Australia/Adelaide',
+            ],
+        ];
+
+        yield from $values;
+
+        foreach ($values as $key => $args) {
+            if ($args[0] === null) {
+                continue;
+            }
+
+            $args[0] = new ArrayObject($args[0]);
+
+            yield $key . ' (ArrayObject)' => $args;
+        }
+    }
+
+    #[DataProvider('timezoneConfigScenarios')]
+    public function testTimeZoneWithVariousConfigurations(iterable|null $config, string $expect): void
+    {
+        $container = $this->containerWithConfig($config);
+        $factory   = new I18nDefaultsFactory();
+        $defaults  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame($expect, $defaults->defaultTimeZone->getName());
+    }
+
+    /** @return list<array{0: string, 1: string, 2: string}> */
+    public static function explicitCurrencyProvider(): array
+    {
+        return [
+            ['en_GB', 'GBP', 'BWP'],
+            ['en_US', 'USD', 'BWP'],
+            ['sw_TZ', 'TZS', 'BWP'],
+            ['sw_ZA', 'ZAR', 'BWP'],
+            ['de_DE', 'EUR', 'BWP'],
+            ['es_MX', 'MXN', 'BWP'],
+            ['es_AR', 'ARS', 'BWP'],
+            ['es_UY', 'UYU', 'BWP'],
+            ['pt_BR', 'BRL', 'BWP'],
+            ['pt_PT', 'EUR', 'BWP'],
+        ];
+    }
+
+    #[DataProvider('explicitCurrencyProvider')]
+    public function testExplicitCurrencySettingOverridesDetectionFromLocale(
+        string $locale,
+        string $localeCurrency,
+        string $configuredCurrency,
+    ): void {
+        $container = $this->containerWithConfig([
+            'locale'       => $locale,
+            'laminas-i18n' => [
+                'defaultCurrency' => $configuredCurrency,
+            ],
+        ]);
+        $factory   = new I18nDefaultsFactory();
+        $defaults  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame($configuredCurrency, $defaults->defaultCurrencyCode);
+        self::assertNotSame($localeCurrency, $defaults->defaultCurrencyCode);
+    }
+
+    /** @return list<array{0: string, 1: string, 2: string}> */
+    public static function explicitCountryProvider(): array
+    {
+        return [
+            ['en_GB', 'GB', 'CA'],
+            ['en_US', 'US', 'CA'],
+            ['sw_TZ', 'TZ', 'CA'],
+            ['sw_ZA', 'ZA', 'CA'],
+            ['de_DE', 'DE', 'CA'],
+            ['es_MX', 'MX', 'CA'],
+            ['es_AR', 'AR', 'CA'],
+            ['es_UY', 'UY', 'CA'],
+            ['pt_BR', 'BR', 'CA'],
+            ['pt_PT', 'PT', 'CA'],
+        ];
+    }
+
+    #[DataProvider('explicitCountryProvider')]
+    public function testExplicitCountrySettingOverridesDetectionFromLocale(
+        string $locale,
+        string $localeCountry,
+        string $configuredCountry,
+    ): void {
+        $container = $this->containerWithConfig([
+            'locale'       => $locale,
+            'laminas-i18n' => [
+                'defaultCountry' => $configuredCountry,
+            ],
+        ]);
+        $factory   = new I18nDefaultsFactory();
+        $defaults  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame($configuredCountry, $defaults->defaultCountry->toString());
+        self::assertNotSame($localeCountry, $defaults->defaultCountry->toString());
+    }
+
+    public function testThatAWonkyLocaleWillNotFailToDetectACurrencyOrCountry(): void
+    {
+        $container = $this->containerWithConfig([
+            'locale' => 'ab_XX',
+        ]);
+        $factory   = new I18nDefaultsFactory();
+        $defaults  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame('XXX', $defaults->defaultCurrencyCode);
+        self::assertSame('XX', $defaults->defaultCountry->toString());
+    }
+
+    public function testDefaultTextDomain(): void
+    {
+        $container = $this->containerWithConfig(null);
+        $factory   = new I18nDefaultsFactory();
+        $defaults  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame('default', $defaults->defaultTextDomain);
+    }
+
+    public function testDefaultTextDomainCanBeConfigured(): void
+    {
+        $container = $this->containerWithConfig([
+            'laminas-i18n' => [
+                'defaultTextDomain' => 'rabbits',
+            ],
+        ]);
+        $factory   = new I18nDefaultsFactory();
+        $defaults  = $factory->__invoke($container, 'whatever');
+
+        self::assertSame('rabbits', $defaults->defaultTextDomain);
+    }
+
+    private function containerWithConfig(iterable|null $config): ContainerInterface
+    {
+        $useObject = $config instanceof Traversable;
+        $config    = array_replace_recursive(
+            (new ConfigProvider())->__invoke(),
+            $config === null ? [] : iterator_to_array($config),
+        );
+
+        /** @psalm-var ServiceManagerConfiguration $deps */
+        $deps             = $config['dependencies'];
+        $config           = $useObject ? new ArrayObject($config) : $config;
+        $deps['services'] = ['config' => $config];
+
+        return new ServiceManager($deps);
+    }
+}


### PR DESCRIPTION
This value object encapsulates various configuration parameters that are needed by disparate libs/classes.

Instead of parsing configuration in multiple libraries, we do it once here and provide a service that validators/filters/view helpers and users can fetch for these important defaults.

