### PR TITLE
Remove MVC affordances and clean up the `LoaderPluginManagerFactory`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,7 @@
         "vimeo/psalm": "^6.14.3"
     },
     "conflict": {
-        "laminas/laminas-view": "<2.20.0",
-        "zendframework/zend-i18n": "*"
+        "laminas/laminas-view": "<2.20.0"
     },
     "suggest": {
         "laminas/laminas-cache": "Provides a PSR-6 cache implementation for caching translations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5fdc769c21aa823fbaac9185ed5b00ff",
+    "content-hash": "683d6f75d423a4882b99638ef8a315ca",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -20,11 +20,6 @@
       <code><![CDATA[LoaderPluginManager]]></code>
     </MethodSignatureMismatch>
   </file>
-  <file src="src/Translator/LoaderPluginManagerFactory.php">
-    <MixedArgument>
-      <code><![CDATA[$config['translator_plugins']]]></code>
-    </MixedArgument>
-  </file>
   <file src="src/Translator/Translator.php">
     <DocblockTypeContradiction>
       <code><![CDATA[is_array($options)]]></code>

--- a/src/Translator/LoaderPluginManagerFactory.php
+++ b/src/Translator/LoaderPluginManagerFactory.php
@@ -8,7 +8,11 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
 
+use function array_replace_recursive;
+use function assert;
 use function is_array;
+use function is_iterable;
+use function iterator_to_array;
 
 /**
  * @internal
@@ -24,30 +28,19 @@ final readonly class LoaderPluginManagerFactory implements FactoryInterface
         string $requestedName,
         ?array $options = null,
     ): LoaderPluginManager {
-        $options     ??= [];
-        $pluginManager = new LoaderPluginManager($container, $options);
+        $options ??= [];
+        /** @psalm-var mixed $config */
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = ! is_iterable($config) ? [] : $config;
+        $config = iterator_to_array($config);
 
-        // If this is in a laminas-mvc application, the ServiceListener will inject
-        // merged configuration during bootstrap.
-        if ($container->has('ServiceListener')) {
-            return $pluginManager;
-        }
+        $plugins = $config['translator_plugins'] ?? [];
+        assert(is_array($plugins));
 
-        // If we do not have a config service, nothing more to do
-        if (! $container->has('config')) {
-            return $pluginManager;
-        }
+        // Merge arguments to build() over plugins in `config`
+        $plugins = array_replace_recursive($plugins, $options);
+        /** @psalm-var ServiceManagerConfiguration $plugins */
 
-        $config = $container->get('config');
-
-        // If we do not have translator_plugins configuration, nothing more to do
-        if (! isset($config['translator_plugins']) || ! is_array($config['translator_plugins'])) {
-            return $pluginManager;
-        }
-
-        // Wire service configuration for translator_plugins
-        $pluginManager->configure($config['translator_plugins']);
-
-        return $pluginManager;
+        return new LoaderPluginManager($container, $plugins);
     }
 }

--- a/test/Translator/LoaderPluginManagerFactoryTest.php
+++ b/test/Translator/LoaderPluginManagerFactoryTest.php
@@ -67,12 +67,10 @@ final class LoaderPluginManagerFactoryTest extends TestCase
         ];
 
         $container = $this->createMock(ContainerInterface::class);
-        $container->expects(self::atLeast(2))
+        $container->expects(self::atLeast(1))
             ->method('has')
-            ->willReturnMap([
-                ['ServiceListener', false],
-                ['config', true],
-            ]);
+            ->with('config')
+            ->willReturn(true);
 
         $container->expects(self::atLeast(1))
             ->method('get')
@@ -89,33 +87,13 @@ final class LoaderPluginManagerFactoryTest extends TestCase
         self::assertSame($translator, $translators->get('test-too'));
     }
 
-    public function testDoesNotConfigureTranslatorServicesWhenServiceListenerPresent(): void
+    public function testDoesNotConfigureTranslatorServicesWhenConfigServiceNotPresent(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $container->expects(self::once())
             ->method('has')
-            ->with('ServiceListener')
-            ->willReturn(true);
-
-        $container->expects(self::never())->method('get');
-
-        $factory     = new LoaderPluginManagerFactory();
-        $translators = $factory($container, 'TranslatorPluginManager');
-
-        self::assertInstanceOf(LoaderPluginManager::class, $translators);
-        self::assertFalse($translators->has('test'));
-        self::assertFalse($translators->has('test-too'));
-    }
-
-    public function testDoesNotConfigureTranslatorServicesWhenConfigServiceNotPresent(): void
-    {
-        $container = $this->createMock(ContainerInterface::class);
-        $container->expects(self::exactly(2))
-            ->method('has')
-            ->willReturnMap([
-                ['ServiceListener', false],
-                ['config', false],
-            ]);
+            ->with('config')
+            ->willReturn(false);
 
         $container->expects(self::never())->method('get');
 
@@ -129,12 +107,10 @@ final class LoaderPluginManagerFactoryTest extends TestCase
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $container->expects(self::exactly(2))
+        $container->expects(self::once())
             ->method('has')
-            ->willReturnMap([
-                ['ServiceListener', false],
-                ['config', true],
-            ]);
+            ->with('config')
+            ->willReturn(true);
 
         $container->expects(self::once())
             ->method('get')

--- a/tools/infection/composer.lock
+++ b/tools/infection/composer.lock
@@ -1786,16 +1786,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.6.3",
+            "version": "6.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "134e98916fa2f663afa623970af345cd788e8967"
+                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/134e98916fa2f663afa623970af345cd788e8967",
-                "reference": "134e98916fa2f663afa623970af345cd788e8967",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2eeb75d21cf73211335888e7f5e6fd7440723ec7",
+                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7",
                 "shasum": ""
             },
             "require": {
@@ -1855,9 +1855,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.3"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.4"
             },
-            "time": "2025-12-02T10:21:33+00:00"
+            "time": "2025-12-19T15:01:32+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -3028,16 +3028,16 @@
         },
         {
             "name": "sanmai/di-container",
-            "version": "0.1.5",
+            "version": "0.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/di-container.git",
-                "reference": "355534ad7970fc7dab4211ecaf2da5c546855ee8"
+                "reference": "f7ea6a00692608f785fc0eabb1c54f5349d973e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/di-container/zipball/355534ad7970fc7dab4211ecaf2da5c546855ee8",
-                "reference": "355534ad7970fc7dab4211ecaf2da5c546855ee8",
+                "url": "https://api.github.com/repos/sanmai/di-container/zipball/f7ea6a00692608f785fc0eabb1c54f5349d973e9",
+                "reference": "f7ea6a00692608f785fc0eabb1c54f5349d973e9",
                 "shasum": ""
             },
             "require": {
@@ -3091,7 +3091,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sanmai/di-container/issues",
-                "source": "https://github.com/sanmai/di-container/tree/0.1.5"
+                "source": "https://github.com/sanmai/di-container/tree/0.1.8"
             },
             "funding": [
                 {
@@ -3099,7 +3099,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-04T09:43:58+00:00"
+            "time": "2026-01-03T14:10:40+00:00"
         },
         {
             "name": "sanmai/duoclock",


### PR DESCRIPTION
Some MVC remnants remained in the `LoaderPluginManagerFactory` from #176. This patch removes them and has a cleanup of the factory.