### PR TITLE
Add PSR6 Caching Translation Collector

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\I18n;
 
+use Laminas\I18n\Translator\TranslationCollector\Factory\PSR6CachingCollectorDelegatorFactory;
 use Laminas\I18n\Translator\TranslationCollector\TranslationCollectorInterface;
 use Laminas\I18n\Translator\Value\TranslationFile;
 use Laminas\I18n\Translator\Value\TranslatorFilePattern;
@@ -50,6 +51,8 @@ final class ConfigProvider
      *             cache?: string|null,
      *             event_manager_enabled?: bool,
      *             fallback_locale?: string|null,
+     *             psr6_cache?: string,
+     *             cache_key_prefix?: non-empty-string|null,
      *         },
      *     },
      *     translator_plugins?: ServiceManagerConfiguration,
@@ -171,11 +174,6 @@ final class ConfigProvider
                     //'aggregate_collector' => [CollectorOne::class, CollectorTwo::class],
 
                     /**
-                     * Provide the id of a cache instance retrievable from the container to enable caching in the translator
-                     */
-                    // 'cache' => SomeCacheService::class,
-
-                    /**
                      * Whether to enable the event manager in the translator
                      */
                     'event_manager_enabled' => false,
@@ -184,6 +182,19 @@ final class ConfigProvider
                      * Optionally provide a fallback locale for when the translators default locale has no translations
                      */
                     'fallback_locale' => null,
+
+                    /**
+                     * When you provide a service name here that points to a PSR-16 cache item pool that is
+                     * retrievable from the DI container, the default translation collector will be wrapped in
+                     * a {@link Translator\TranslationCollector\PSR6CachingCollector}
+                     */
+                    // 'psr6_cache' => 'Some Cache Service ID',
+
+                    /**
+                     * You can customise the cache-key prefix if you want.
+                     * By default, it is 'LaminasTranslations'
+                     */
+                    'cache_key_prefix' => null,
                 ],
             ],
         ];
@@ -197,14 +208,14 @@ final class ConfigProvider
     public function getDependencyConfig(): array
     {
         return [
-            'aliases'   => [
+            'aliases'    => [
                 'TranslatorPluginManager'                             => Translator\LoaderPluginManager::class,
                 Translator\MessageLoaderPluginManagerInterface::class => Translator\LoaderPluginManager::class,
                 TranslationCollectorInterface::class                  => Translator\TranslationCollector\AggregateCollector::class,
                 Geography\CountryCodeListInterface::class             => Geography\DefaultCountryCodeList::class,
                 TranslatorInterface::class                            => Translator\Translator::class,
             ],
-            'factories' => [
+            'factories'  => [
                 Translator\TranslationCollector\AggregateCollector::class   => Translator\TranslationCollector\Factory\AggregateCollectorFactory::class,
                 Translator\TranslationCollector\FileListCollector::class    => Translator\TranslationCollector\Factory\FileListCollectorFactory::class,
                 Translator\TranslationCollector\FilePatternCollector::class => Translator\TranslationCollector\Factory\FilePatternCollectorFactory::class,
@@ -215,6 +226,11 @@ final class ConfigProvider
                 Geography\DefaultCountryCodeList::class                     => Geography\DefaultCountryCodeListFactory::class,
                 DefaultLocale::class                                        => Factory\DefaultLocaleFactory::class,
                 I18nDefaults::class                                         => Factory\I18nDefaultsFactory::class,
+            ],
+            'delegators' => [
+                Translator\TranslationCollector\AggregateCollector::class => [
+                    PSR6CachingCollectorDelegatorFactory::class => PSR6CachingCollectorDelegatorFactory::class,
+                ],
             ],
         ];
     }

--- a/src/Translator/TranslationCollector/Factory/PSR6CachingCollectorDelegatorFactory.php
+++ b/src/Translator/TranslationCollector/Factory/PSR6CachingCollectorDelegatorFactory.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Translator\TranslationCollector\Factory;
+
+use Laminas\I18n\Exception\InvalidArgumentException;
+use Laminas\I18n\Exception\RuntimeException;
+use Laminas\I18n\Translator\TranslationCollector\PSR6CachingCollector;
+use Laminas\I18n\Translator\TranslationCollector\TranslationCollectorInterface;
+use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+use function get_debug_type;
+use function is_array;
+use function is_iterable;
+use function is_string;
+use function iterator_to_array;
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-internal Laminas\I18n
+ * @psalm-internal LaminasTest\I18n
+ */
+final readonly class PSR6CachingCollectorDelegatorFactory implements DelegatorFactoryInterface
+{
+    public function __invoke(
+        ContainerInterface $container,
+        string $name,
+        callable $callback,
+        ?array $options = null,
+    ): TranslationCollectorInterface {
+        $collector = $callback();
+        if (! $collector instanceof TranslationCollectorInterface) {
+            throw new RuntimeException(sprintf(
+                'Expected the delegated service to be a translation collector but received "%s"',
+                get_debug_type($collector),
+            ));
+        }
+
+        /** @psalm-var mixed $config */
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = is_iterable($config) ? iterator_to_array($config) : [];
+
+        $i18n = $config['laminas-i18n'] ?? [];
+        assert(is_array($i18n));
+
+        $translator = $i18n['translator'] ?? [];
+        assert(is_array($translator));
+
+        /** @psalm-var mixed $cacheService */
+        $cacheService = $translator['psr6_cache'] ?? null;
+        if (! is_string($cacheService) || ! $container->has($cacheService)) {
+            return $collector;
+        }
+
+        $cache = $container->get($cacheService);
+        if (! $cache instanceof CacheItemPoolInterface) {
+            return $collector;
+        }
+
+        /** @psalm-var mixed $prefix */
+        $prefix = $translator['cache_key_prefix'] ?? null;
+        if ($prefix !== null && (! is_string($prefix) || $prefix === '')) {
+            throw new InvalidArgumentException(
+                'The `cache_key_prefix` option must resolve to null or a non-empty-string',
+            );
+        }
+
+        /** @psalm-var non-empty-string|null $prefix */
+
+        return new PSR6CachingCollector(
+            $cache,
+            $collector,
+            $prefix,
+        );
+    }
+}

--- a/src/Translator/TranslationCollector/PSR6CachingCollector.php
+++ b/src/Translator/TranslationCollector/PSR6CachingCollector.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\Translator\TranslationCollector;
+
+use Laminas\I18n\Exception\RuntimeException;
+use Laminas\I18n\Translator\TextDomain;
+use Psr\Cache\CacheItemPoolInterface;
+
+use function get_debug_type;
+use function sprintf;
+
+final readonly class PSR6CachingCollector implements TranslationCollectorInterface
+{
+    private const DEFAULT_PREFIX = 'LaminasTranslations';
+    /** @var non-empty-string */
+    private string $keyPrefix;
+
+    /** @param non-empty-string|null $keyPrefix */
+    public function __construct(
+        private CacheItemPoolInterface $cache,
+        private TranslationCollectorInterface $collector,
+        string|null $keyPrefix = null,
+    ) {
+        $this->keyPrefix = $keyPrefix ?? self::DEFAULT_PREFIX;
+    }
+
+    public function collect(string $textDomain, string $locale): TextDomain
+    {
+        $key  = $this->cacheKey($textDomain, $locale);
+        $item = $this->cache->getItem($key);
+        if ($item->isHit()) {
+            return $this->assertTextDomain($key, $item->get());
+        }
+
+        $data = $this->collector->collect($textDomain, $locale);
+        $item->set($data);
+        $this->cache->save($item);
+
+        return $data;
+    }
+
+    /**
+     * Return the cache item key for a text-domain and locale pair
+     *
+     * @param non-empty-string $textDomain
+     * @param non-empty-string $locale
+     * @return non-empty-string
+     */
+    public function cacheKey(string $textDomain, string $locale): string
+    {
+        return sprintf('%s-%s-%s', $this->keyPrefix, $textDomain, $locale);
+    }
+
+    /**
+     * Remove the translations identified by text domain and locale from the cache
+     *
+     * @param non-empty-string $textDomain
+     * @param non-empty-string $locale
+     */
+    public function clearCache(string $textDomain, string $locale): void
+    {
+        $this->cache->deleteItem($this->cacheKey($textDomain, $locale));
+    }
+
+    private function assertTextDomain(string $key, mixed $value): TextDomain
+    {
+        if (! $value instanceof TextDomain) {
+            throw new RuntimeException(sprintf(
+                'Expected the cache key "%s" to contain translation messages but it was "%s"',
+                $key,
+                get_debug_type($value),
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -10,11 +10,8 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\I18n\Exception\ExceptionInterface;
 use Laminas\I18n\Translator\TranslationCollector\TranslationCollectorInterface;
 use Laminas\Translator\TranslatorInterface;
-use Psr\Cache\CacheItemPoolInterface;
 
-use function assert;
 use function is_string;
-use function md5;
 
 final class Translator implements TranslatorInterface
 {
@@ -36,8 +33,6 @@ final class Translator implements TranslatorInterface
      * @var array<non-empty-string, array<non-empty-string, TextDomain|null>>
      */
     private array $messages = [];
-
-    private CacheItemPoolInterface|null $cache = null;
 
     private readonly EventManagerInterface $events;
     private bool $eventsEnabled = false;
@@ -87,13 +82,6 @@ final class Translator implements TranslatorInterface
     public function getLocale(): string
     {
         return $this->defaultLocale;
-    }
-
-    public function setCache(CacheItemPoolInterface|null $cache = null): self
-    {
-        $this->cache = $cache;
-
-        return $this;
     }
 
     /**
@@ -231,26 +219,6 @@ final class Translator implements TranslatorInterface
     }
 
     /**
-     * Get the cache identifier for a specific textDomain and locale.
-     */
-    public function getCacheId(string $textDomain, string $locale): string
-    {
-        return 'Laminas_I18n_Translator_Messages_' . md5($textDomain . $locale);
-    }
-
-    /**
-     * Clears the cache for a specific textDomain and locale.
-     */
-    public function clearCache(string $textDomain, string $locale): bool
-    {
-        if ($this->cache === null) {
-            return false;
-        }
-
-        return $this->cache->deleteItem($this->getCacheId($textDomain, $locale));
-    }
-
-    /**
      * Load messages for a given language and domain.
      *
      * @param non-empty-string $textDomain
@@ -261,19 +229,6 @@ final class Translator implements TranslatorInterface
     private function loadMessages(string $textDomain, string $locale): void
     {
         $this->messages[$textDomain] ??= [];
-
-        if ($this->cache !== null) {
-            $cacheId = $this->getCacheId($textDomain, $locale);
-            $item    = $this->cache->getItem($cacheId);
-            if ($item->isHit()) {
-                $value = $item->get();
-                assert($value instanceof TextDomain);
-
-                $this->messages[$textDomain][$locale] = $value;
-
-                return;
-            }
-        }
 
         $messages = $this->collector->collect($textDomain, $locale);
 
@@ -299,13 +254,6 @@ final class Translator implements TranslatorInterface
         }
 
         $this->messages[$textDomain][$locale] = $messages;
-
-        if ($this->cache !== null) {
-            $cacheId = $this->getCacheId($textDomain, $locale);
-            $item    = $this->cache->getItem($cacheId);
-            $item->set($messages);
-            $this->cache->save($item);
-        }
     }
 
     /**

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -7,7 +7,6 @@ namespace Laminas\I18n\Translator;
 use Laminas\I18n\I18nDefaults;
 use Laminas\I18n\Translator\TranslationCollector\TranslationCollectorInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use Psr\Cache\CacheItemPoolInterface;
 use Psr\Container\ContainerInterface;
 
 use function assert;
@@ -59,19 +58,6 @@ final readonly class TranslatorServiceFactory implements FactoryInterface
         $fallbackLocale = $translator['fallback_locale'] ?? null;
         $fallbackLocale = is_string($fallbackLocale) && $fallbackLocale !== '' ? $fallbackLocale : null;
 
-        /**
-         * Retrieve the cache service (if any) from the container
-         *
-         * @todo Replace this with a caching decorator
-         * @psalm-var mixed $cacheService
-         */
-        $cacheService = $translator['cache'] ?? null;
-        /** @psalm-var mixed $cacheService */
-        $cacheService = is_string($cacheService) && $container->has($cacheService)
-            ? $container->get($cacheService)
-            : null;
-        assert($cacheService instanceof CacheItemPoolInterface || $cacheService === null);
-
         /** @psalm-var mixed $enableEvents */
         $enableEvents = $translator['event_manager_enabled'] ?? false;
         $enableEvents = is_bool($enableEvents) && $enableEvents;
@@ -81,10 +67,6 @@ final readonly class TranslatorServiceFactory implements FactoryInterface
             $locale,
             $fallbackLocale,
         );
-
-        if ($cacheService instanceof CacheItemPoolInterface) {
-            $instance->setCache($cacheService);
-        }
 
         if ($enableEvents) {
             $instance->enableEventManager();

--- a/test/Translator/TranslationCollector/Factory/PSR6CachingCollectorDelegatorFactoryTest.php
+++ b/test/Translator/TranslationCollector/Factory/PSR6CachingCollectorDelegatorFactoryTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\I18n\Translator\TranslationCollector\Factory;
+
+use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
+use Laminas\Cache\Storage\Adapter\Memory;
+use Laminas\I18n\Exception\InvalidArgumentException;
+use Laminas\I18n\Exception\RuntimeException;
+use Laminas\I18n\Translator\TranslationCollector\Factory\PSR6CachingCollectorDelegatorFactory;
+use Laminas\I18n\Translator\TranslationCollector\PSR6CachingCollector;
+use LaminasTest\I18n\Translator\TranslationCollector\FixedCollector;
+use LaminasTest\I18n\Translator\TranslationCollector\TestHelper;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerInterface;
+
+final class PSR6CachingCollectorDelegatorFactoryTest extends TestCase
+{
+    private CacheItemPoolInterface $cache;
+
+    protected function setUp(): void
+    {
+        $this->cache = new CacheItemPoolDecorator(new Memory());
+    }
+
+    public function testExceptionThrownWhenDelegatedServiceIsNotACollector(): void
+    {
+        $factory = new PSR6CachingCollectorDelegatorFactory();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Expected the delegated service to be a translation collector but received "string"',
+        );
+        $factory->__invoke(
+            $this->createStub(ContainerInterface::class),
+            'foo',
+            static fn(): string => 'Foo',
+        );
+    }
+
+    public function testWhenTheCacheServiceIsNotConfiguredTheCollectorIsNotDelegated(): void
+    {
+        $collector = FixedCollector::make();
+
+        $factory = new PSR6CachingCollectorDelegatorFactory();
+
+        $result = $factory->__invoke(
+            TestHelper::containerWithConfig([]),
+            'foo',
+            static fn(): FixedCollector => $collector,
+        );
+
+        self::assertSame($collector, $result);
+    }
+
+    public function testInvalidCacheServicesAreIgnored(): void
+    {
+        $collector = FixedCollector::make();
+
+        $factory = new PSR6CachingCollectorDelegatorFactory();
+
+        $result = $factory->__invoke(
+            TestHelper::containerWithConfig([
+                'laminas-i18n' => [
+                    'translator' => [
+                        'psr6_cache' => 'ServiceName',
+                    ],
+                ],
+                'dependencies' => [
+                    'services' => [
+                        'ServiceName' => 'Not a cache',
+                    ],
+                ],
+            ]),
+            'foo',
+            static fn(): FixedCollector => $collector,
+        );
+
+        self::assertSame($collector, $result);
+    }
+
+    public function testServiceIsDelegatedWhenCacheServiceIsAvailable(): void
+    {
+        $collector = FixedCollector::make();
+
+        $factory = new PSR6CachingCollectorDelegatorFactory();
+
+        $result = $factory->__invoke(
+            TestHelper::containerWithConfig([
+                'laminas-i18n' => [
+                    'translator' => [
+                        'psr6_cache' => 'ServiceName',
+                    ],
+                ],
+                'dependencies' => [
+                    'services' => [
+                        'ServiceName' => $this->cache,
+                    ],
+                ],
+            ]),
+            'foo',
+            static fn(): FixedCollector => $collector,
+        );
+
+        self::assertNotSame($collector, $result);
+        self::assertInstanceOf(PSR6CachingCollector::class, $result);
+    }
+
+    public function testCachePrefixCanBeCustomised(): void
+    {
+        $collector = FixedCollector::make();
+
+        $factory = new PSR6CachingCollectorDelegatorFactory();
+
+        $result = $factory->__invoke(
+            TestHelper::containerWithConfig([
+                'laminas-i18n' => [
+                    'translator' => [
+                        'psr6_cache'       => 'ServiceName',
+                        'cache_key_prefix' => 'Goats',
+                    ],
+                ],
+                'dependencies' => [
+                    'services' => [
+                        'ServiceName' => $this->cache,
+                    ],
+                ],
+            ]),
+            'foo',
+            static fn(): FixedCollector => $collector,
+        );
+
+        self::assertNotSame($collector, $result);
+        self::assertInstanceOf(PSR6CachingCollector::class, $result);
+
+        self::assertSame(
+            'Goats-default-en_GB',
+            $result->cacheKey('default', 'en_GB'),
+        );
+    }
+
+    public function testExceptionThrownForInvalidCacheKeyPrefix(): void
+    {
+        $collector = FixedCollector::make();
+
+        $factory = new PSR6CachingCollectorDelegatorFactory();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `cache_key_prefix` option must resolve to null or a non-empty-string');
+        $factory->__invoke(
+            TestHelper::containerWithConfig([
+                'laminas-i18n' => [
+                    'translator' => [
+                        'psr6_cache'       => 'ServiceName',
+                        'cache_key_prefix' => 123,
+                    ],
+                ],
+                'dependencies' => [
+                    'services' => [
+                        'ServiceName' => $this->cache,
+                    ],
+                ],
+            ]),
+            'foo',
+            static fn(): FixedCollector => $collector,
+        );
+    }
+}

--- a/test/Translator/TranslationCollector/FixedCollector.php
+++ b/test/Translator/TranslationCollector/FixedCollector.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\I18n\Translator\TranslationCollector;
+
+use Laminas\I18n\Translator\TextDomain;
+use Laminas\I18n\Translator\TranslationCollector\TranslationCollectorInterface;
+
+final readonly class FixedCollector implements TranslationCollectorInterface
+{
+    public function __construct(public TextDomain $textDomain)
+    {
+    }
+
+    public function collect(string $textDomain, string $locale): TextDomain
+    {
+        return $this->textDomain;
+    }
+
+    public static function make(): self
+    {
+        return new self(new TextDomain(['Message' => 'Translated']));
+    }
+}

--- a/test/Translator/TranslationCollector/PSR6CachingCollectorTest.php
+++ b/test/Translator/TranslationCollector/PSR6CachingCollectorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\I18n\Translator\TranslationCollector;
+
+use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
+use Laminas\Cache\Storage\Adapter\Memory;
+use Laminas\I18n\Exception\RuntimeException;
+use Laminas\I18n\Translator\TextDomain;
+use Laminas\I18n\Translator\TranslationCollector\PSR6CachingCollector;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class PSR6CachingCollectorTest extends TestCase
+{
+    private CacheItemPoolInterface $cache;
+    private FixedCollector $collector;
+
+    protected function setUp(): void
+    {
+        $this->cache     = new CacheItemPoolDecorator(new Memory());
+        $this->collector = new FixedCollector(new TextDomain([
+            'Message' => 'Translation',
+        ]));
+    }
+
+    public function testCollectedMessagesAreCached(): void
+    {
+        $collector = new PSR6CachingCollector(
+            $this->cache,
+            $this->collector,
+        );
+
+        $item = $this->cache->getItem($collector->cacheKey('default', 'en_GB'));
+        self::assertFalse($item->isHit());
+
+        $result = $collector->collect('default', 'en_GB');
+        self::assertSame('Translation', $result['Message']);
+
+        $item = $this->cache->getItem($collector->cacheKey('default', 'en_GB'));
+        self::assertTrue($item->isHit());
+
+        $cached = $item->get();
+        self::assertInstanceOf(TextDomain::class, $cached);
+        self::assertSame('Translation', $cached['Message']);
+
+        self::assertSame($cached, $collector->collect('default', 'en_GB'));
+    }
+
+    public function testCollectedMessagesCanBeCleared(): void
+    {
+        $collector = new PSR6CachingCollector(
+            $this->cache,
+            $this->collector,
+        );
+
+        $item = $this->cache->getItem($collector->cacheKey('default', 'en_GB'));
+        self::assertFalse($item->isHit());
+
+        $collector->collect('default', 'en_GB');
+
+        $item = $this->cache->getItem($collector->cacheKey('default', 'en_GB'));
+        self::assertTrue($item->isHit());
+
+        $collector->clearCache('default', 'en_GB');
+
+        $item = $this->cache->getItem($collector->cacheKey('default', 'en_GB'));
+        self::assertFalse($item->isHit());
+    }
+
+    public function testExceptionThrownWhenCachedItemIsNotATextDomainInstance(): void
+    {
+        $collector = new PSR6CachingCollector(
+            $this->cache,
+            $this->collector,
+        );
+
+        $item = $this->cache->getItem($collector->cacheKey('default', 'en_GB'));
+        $item->set('Whatever');
+        $this->cache->save($item);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Expected the cache key "LaminasTranslations-default-en_GB" '
+            . 'to contain translation messages but it was "string"',
+        );
+
+        $collector->collect('default', 'en_GB');
+    }
+
+    public function testTheCacheKeyPrefixCanBeCustomised(): void
+    {
+        $collector = new PSR6CachingCollector(
+            $this->cache,
+            $this->collector,
+            'Kermit',
+        );
+
+        self::assertSame(
+            'Kermit-default-en_GB',
+            $collector->cacheKey('default', 'en_GB'),
+        );
+    }
+}

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\I18n\Translator;
 
-use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
-use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\EventManager;
@@ -151,78 +149,6 @@ final class TranslatorTest extends TestCase
         $translator = new Translator($collector, 'en_US');
 
         self::assertEquals('bar', $translator->translate('foo'));
-    }
-
-    public function testTranslationsLoadedFromCache(): void
-    {
-        $textDomain = new TextDomain(['foo' => 'bar']);
-
-        $collector = $this->createMock(TranslationCollectorInterface::class);
-        $collector->expects($this->never())
-            ->method('collect');
-
-        $translator = new Translator($collector, 'en_US');
-
-        $cache = new CacheItemPoolDecorator(new Memory());
-        $translator->setCache($cache);
-
-        $item = $cache->getItem($translator->getCacheId('default', 'en_US'));
-        $item->set($textDomain);
-        $cache->save($item);
-
-        self::assertEquals('bar', $translator->translate('foo'));
-    }
-
-    public function testTranslationsAreStoredInCache(): void
-    {
-        $cache = new CacheItemPoolDecorator(new Memory());
-
-        $textDomain = new TextDomain(['foo' => 'bar']);
-
-        $collector = $this->createMock(TranslationCollectorInterface::class);
-        $collector->expects($this->once())
-            ->method('collect')
-            ->with('default', 'en_US')
-            ->willReturn($textDomain);
-
-        $translator = new Translator($collector, 'en_US');
-        $translator->setCache($cache);
-
-        self::assertEquals('bar', $translator->translate('foo'));
-
-        $item   = $cache->getItem($translator->getCacheId('default', 'en_US'));
-        $result = $item->get();
-        self::assertInstanceOf(TextDomain::class, $result);
-        self::assertEquals('bar', $result['foo']);
-    }
-
-    public function testTranslationsAreClearedFromCache(): void
-    {
-        $cache = new CacheItemPoolDecorator(new Memory());
-
-        $textDomain = new TextDomain(['foo' => 'bar']);
-
-        $collector = $this->createMock(TranslationCollectorInterface::class);
-        $collector->expects($this->never())
-            ->method('collect');
-
-        $translator = new Translator($collector, 'en_US');
-        $translator->setCache($cache);
-
-        $item = $cache->getItem($translator->getCacheId('default', 'en_US'));
-        $item->set($textDomain);
-        $cache->save($item);
-
-        self::assertTrue($translator->clearCache('default', 'en_US'));
-
-        $item = $cache->getItem($translator->getCacheId('default', 'en_US'));
-        self::assertFalse($item->isHit());
-    }
-
-    public function testClearCacheReturnsFalseIfNoCacheIsPresent(): void
-    {
-        $translator = new Translator($this->createStub(TranslationCollectorInterface::class), 'en_US');
-        self::assertFalse($translator->clearCache('default', 'en_US'));
     }
 
     public function testTranslatePlurals(): void


### PR DESCRIPTION
… with a pre-wired delegator factory that conditionally decorates the aggregate collector when a cache service has been configured.

Also removes cache features from the translator

BTW, it would be trivial to support PSR-16 at the same time (in another patch)