### PR TITLE
Configurable Default Text Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # laminas-i18n
 
-[![Build Status](https://github.com/laminas/laminas-i18n/workflows/Continuous%20Integration/badge.svg)](https://github.com/laminas/laminas-i18n/actions?query=workflow%3A"Continuous+Integration")
+[![Build Status](https://github.com/laminas/laminas-i18n/workflows/Continuous%20Integration/badge.svg)](https://github.com/laminas/laminas-i18n/actions?query=workflow%3A"Continuous+Integration") [![Type Coverage](https://shepherd.dev/github/laminas/laminas-i18n/coverage.svg)](https://shepherd.dev/github/laminas/laminas-i18n)
 
 > ## 🇷🇺 Русским гражданам
 >

--- a/src/Factory/I18nDefaultsFactory.php
+++ b/src/Factory/I18nDefaultsFactory.php
@@ -9,6 +9,7 @@ use Laminas\I18n\CountryCode;
 use Laminas\I18n\DefaultLocale;
 use Laminas\I18n\I18nDefaults;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\Translator\TranslatorInterface;
 use Locale;
 use NumberFormatter;
 use Psr\Container\ContainerInterface;
@@ -60,7 +61,9 @@ final readonly class I18nDefaultsFactory implements FactoryInterface
         assert(is_string($country) && $country !== '');
 
         $textDomain = $i18nDefaults['defaultTextDomain'] ?? null;
-        $textDomain = ! is_string($textDomain) || $textDomain === '' ? 'default' : $textDomain;
+        $textDomain = ! is_string($textDomain) || $textDomain === ''
+            ? TranslatorInterface::DEFAULT_TEXT_DOMAIN
+            : $textDomain;
 
         return new I18nDefaults(
             new DateTimeZone($timezone),

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -40,11 +40,13 @@ final class Translator implements TranslatorInterface
     /**
      * @param non-empty-string $defaultLocale
      * @param non-empty-string|null $fallbackLocale
+     * @param non-empty-string $defaultTextDomain
      */
     public function __construct(
         private readonly TranslationCollectorInterface $collector,
         private string $defaultLocale,
         private readonly string|null $fallbackLocale = null,
+        private readonly string $defaultTextDomain = TranslatorInterface::DEFAULT_TEXT_DOMAIN,
         EventManagerInterface|null $eventManager = null,
     ) {
         // When an EventManager is supplied to the constructor, enable events. The user clearly wants them!
@@ -94,10 +96,11 @@ final class Translator implements TranslatorInterface
      */
     public function translate(
         string $message,
-        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
+        string|null $textDomain = null,
         string|null $locale = null,
     ): string {
-        $locale    ??= $this->defaultLocale;
+        $locale     ??= $this->defaultLocale;
+        $textDomain ??= $this->defaultTextDomain;
         $translation = $this->getTranslatedMessage($message, $locale, $textDomain);
 
         if (is_string($translation) && $translation !== '') {
@@ -114,7 +117,7 @@ final class Translator implements TranslatorInterface
     /**
      * Translate a plural message.
      *
-     * @param non-empty-string $textDomain
+     * @param non-empty-string|null $textDomain
      * @param non-empty-string|null $locale
      * @psalm-suppress MoreSpecificImplementedParamType This will be redundant when Translator interface is improved
      */
@@ -122,10 +125,11 @@ final class Translator implements TranslatorInterface
         string $singular,
         string $plural,
         int $number,
-        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
+        string|null $textDomain = null,
         string|null $locale = null,
     ): string {
-        $locale    ??= $this->defaultLocale;
+        $locale     ??= $this->defaultLocale;
+        $textDomain ??= $this->defaultTextDomain;
         $translation = $this->getTranslatedMessage($singular, $locale, $textDomain);
 
         if (is_string($translation)) {
@@ -163,10 +167,10 @@ final class Translator implements TranslatorInterface
      * @param non-empty-string $textDomain
      * @return string|null|list<string|null>
      */
-    protected function getTranslatedMessage(
+    private function getTranslatedMessage(
         string|null $message,
         string $locale,
-        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
+        string $textDomain,
     ): string|array|null {
         if ($message === '' || $message === null) {
             return null;
@@ -259,14 +263,15 @@ final class Translator implements TranslatorInterface
     /**
      * Return all the messages.
      *
-     * @param non-empty-string $textDomain
+     * @param non-empty-string|null $textDomain
      * @param non-empty-string|null $locale
      */
     public function getAllMessages(
-        string $textDomain = self::DEFAULT_TEXT_DOMAIN,
+        string|null $textDomain = null,
         string|null $locale = null,
     ): TextDomain|null {
-        $locale ??= $this->getLocale();
+        $locale     ??= $this->getLocale();
+        $textDomain ??= $this->defaultTextDomain;
 
         if (! isset($this->messages[$textDomain][$locale])) {
             $this->loadMessages($textDomain, $locale);

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -66,6 +66,7 @@ final readonly class TranslatorServiceFactory implements FactoryInterface
             $container->get(TranslationCollectorInterface::class),
             $locale,
             $fallbackLocale,
+            $defaults->defaultTextDomain,
         );
 
         if ($enableEvents) {

--- a/test/Factory/I18nDefaultsFactoryTest.php
+++ b/test/Factory/I18nDefaultsFactoryTest.php
@@ -8,6 +8,7 @@ use ArrayObject;
 use Laminas\I18n\ConfigProvider;
 use Laminas\I18n\Factory\I18nDefaultsFactory;
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Translator\TranslatorInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -192,7 +193,7 @@ final class I18nDefaultsFactoryTest extends TestCase
         $factory   = new I18nDefaultsFactory();
         $defaults  = $factory->__invoke($container, 'whatever');
 
-        self::assertSame('default', $defaults->defaultTextDomain);
+        self::assertSame(TranslatorInterface::DEFAULT_TEXT_DOMAIN, $defaults->defaultTextDomain);
     }
 
     public function testDefaultTextDomainCanBeConfigured(): void

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -26,11 +26,16 @@ final class TranslatorServiceFactoryTest extends TestCase
                     'DE Only'   => 'DE Only Message',
                 ],
             ],
+            'other'   => [
+                'en_GB' => [
+                    'Message 1' => 'Message (Other) en_GB',
+                ],
+            ],
         ]);
 
         $scenarios = [
-            'No config'               => [[], 'Foo', 'Foo'],
-            'Default locale is used'  => [
+            'No config'                   => [[], 'Foo', 'Foo'],
+            'Default locale is used'      => [
                 [
                     'locale'             => 'en_GB',
                     'laminas-i18n'       => [
@@ -49,7 +54,27 @@ final class TranslatorServiceFactoryTest extends TestCase
                 'Message 1',
                 'Message 1 en_GB',
             ],
-            'Fallback locale is used' => [
+            'Default text domain is used' => [
+                [
+                    'locale'             => 'en_GB',
+                    'laminas-i18n'       => [
+                        'defaultTextDomain' => 'other',
+                        'translator'        => [
+                            'remote_translation' => [
+                                ['type' => 'RemoteService'],
+                            ],
+                        ],
+                    ],
+                    'translator_plugins' => [
+                        'services' => [
+                            'RemoteService' => $messages,
+                        ],
+                    ],
+                ],
+                'Message 1',
+                'Message 1 (Other) en_GB',
+            ],
+            'Fallback locale is used'     => [
                 [
                     'locale'             => 'en_GB',
                     'laminas-i18n'       => [

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -72,7 +72,7 @@ final class TranslatorServiceFactoryTest extends TestCase
                     ],
                 ],
                 'Message 1',
-                'Message 1 (Other) en_GB',
+                'Message (Other) en_GB',
             ],
             'Fallback locale is used'     => [
                 [

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -12,6 +12,7 @@ use Laminas\I18n\Translator\Loader\PhpArray;
 use Laminas\I18n\Translator\TextDomain;
 use Laminas\I18n\Translator\TranslationCollector\TranslationCollectorInterface;
 use Laminas\I18n\Translator\Translator;
+use Laminas\Translator\TranslatorInterface;
 use LaminasTest\I18n\Translator\TranslationCollector\TestHelper;
 use Locale;
 use PHPUnit\Framework\TestCase;
@@ -367,6 +368,7 @@ final class TranslatorTest extends TestCase
             $container->get(TranslationCollectorInterface::class),
             'en_GB',
             null,
+            TranslatorInterface::DEFAULT_TEXT_DOMAIN,
             $eventManager,
         );
 
@@ -567,5 +569,29 @@ final class TranslatorTest extends TestCase
         ]);
 
         self::assertEquals('Message 8 (en)', $translator->translate('Message 8'));
+    }
+
+    public function testTheDefaultTextDomainIsUsedAsConfiguredInTranslate(): void
+    {
+        $collector = $this->createMock(TranslationCollectorInterface::class);
+        $collector->expects($this->once())
+            ->method('collect')
+            ->with('kermit', 'en_GB')
+            ->willReturn(new TextDomain(['foo' => 'bar']));
+
+        $translator = new Translator($collector, 'en_GB', null, 'kermit');
+        self::assertSame('bar', $translator->translate('foo'));
+    }
+
+    public function testTheGlobalDefaultTextDomainIsUsedWhenTextDomainIsNotSpecified(): void
+    {
+        $collector = $this->createMock(TranslationCollectorInterface::class);
+        $collector->expects($this->once())
+            ->method('collect')
+            ->with(TranslatorInterface::DEFAULT_TEXT_DOMAIN, 'en_GB')
+            ->willReturn(new TextDomain(['foo' => 'bar']));
+
+        $translator = new Translator($collector, 'en_GB');
+        self::assertSame('bar', $translator->translate('foo'));
     }
 }


### PR DESCRIPTION
Updates translator and its factory so that the configured default text domain is provided to the translator and amends references to the string literal `'default'` to use the constant from `TranslatorInterface`