### PR TITLE
Rework `CountryCode::tryFromString()` for improved performance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,5 @@ composer.lock export-ignore
 /tools/ export-ignore
 /.psr-container.php.stub export-ignore
 .infection.json5.dist export-ignore
+phpbench.json export-ignore
+benchmarks export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /phpunit.xml
 /vendor/
 .markdownlint.json
+/.phpbench/

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,11 @@ test: ## Run tests
 	@docker run $(DOCKER_PHP) vendor/bin/phpunit
 .PHONY: test
 
+bench: ## Run benchmarks
+	@$(call MK_INFO,"Running Benchmarks")
+	docker run $(DOCKER_PHP) vendor/bin/phpbench run --report=aggregate
+.PHONY: bench
+
 composer-checks: ## Dump the composer autoloader
 	@$(call MK_INFO,"Validating composer.json and dumping the autoloader")
 	@docker run $(DOCKER_PHP) composer validate --strict

--- a/benchmarks/CountryCodeTryFromStringBench.php
+++ b/benchmarks/CountryCodeTryFromStringBench.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasBench\I18n;
+
+use Laminas\I18n\CountryCode;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+
+#[Revs(100)]
+#[Iterations(20)]
+#[Warmup(2)]
+final readonly class CountryCodeTryFromStringBench
+{
+    private const INVALID = [
+        'Empty String'         => '',
+        'Invalid Country Code' => 'ZZ',
+        'Invalid String'       => 'wrong',
+        'Numeric String'       => '123',
+        'Invalid Locale'       => 'zz_ZZ',
+    ];
+
+    private const VALID = [
+        'GB',
+        'UA',
+        'us',
+        'sl-Latn-IT-nedis',
+        'de_DE',
+    ];
+
+    public function benchInvalidArgumentToTryFromString(): void
+    {
+        foreach (self::INVALID as $input) {
+            /** @psalm-suppress PossiblyInvalidArgument */
+            CountryCode::tryFromString($input);
+        }
+    }
+
+    public function benchValidInputFromString(): void
+    {
+        foreach (self::VALID as $input) {
+            CountryCode::tryFromString($input);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "laminas/laminas-filter": "^2.42",
         "laminas/laminas-validator": "^2.65.0",
         "laminas/laminas-view": "^2.44",
+        "phpbench/phpbench": "^1.6",
         "phpunit/phpunit": "^11.5.46",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.14.2"
@@ -75,7 +76,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "LaminasTest\\I18n\\": "test/"
+            "LaminasTest\\I18n\\": "test/",
+            "LaminasBench\\I18n\\": "benchmarks/"
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa6000e7e56a453958b9b771992fb564",
+    "content-hash": "b27d9a7a1dfb9b14eebf33224b3cf106",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -1589,6 +1589,83 @@
             "time": "2019-12-04T15:06:13+00:00"
         },
         {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "abandoned": true,
+            "time": "2024-09-05T10:17:24+00:00"
+        },
+        {
             "name": "doctrine/deprecations",
             "version": "1.1.6",
             "source": {
@@ -1635,6 +1712,83 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:56:58+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -3026,6 +3180,156 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpbench/container",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/container.git",
+                "reference": "0c7b2d36c1ea53fe27302fb8873ded7172047196"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/container/zipball/0c7b2d36c1ea53fe27302fb8873ded7172047196",
+                "reference": "0c7b2d36c1ea53fe27302fb8873ded7172047196",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0|^2.0",
+                "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.89",
+                "phpstan/phpstan": "^0.12.52",
+                "phpunit/phpunit": "^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\DependencyInjection\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "Simple, configurable, service container.",
+            "support": {
+                "issues": "https://github.com/phpbench/container/issues",
+                "source": "https://github.com/phpbench/container/tree/2.2.3"
+            },
+            "time": "2025-11-06T09:05:13+00:00"
+        },
+        {
+            "name": "phpbench/phpbench",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/phpbench.git",
+                "reference": "661c8c6abbc7734986cf7bc6062c237fbb450461"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/661c8c6abbc7734986cf7bc6062c237fbb450461",
+                "reference": "661c8c6abbc7734986cf7bc6062c237fbb450461",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "ext-tokenizer": "*",
+                "php": "^8.2",
+                "phpbench/container": "^2.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "seld/jsonlint": "^1.1",
+                "symfony/console": "^6.1 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^6.1 || ^7.0 || ^8.0",
+                "symfony/finder": "^6.1 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^6.1 || ^7.0 || ^8.0",
+                "symfony/process": "^6.1 || ^7.0 || ^8.0",
+                "webmozart/glob": "^4.6"
+            },
+            "require-dev": {
+                "dantleech/invoke": "^2.0",
+                "ergebnis/composer-normalize": "^2.39",
+                "jangregor/phpstan-prophecy": "^1.0",
+                "php-cs-fixer/shim": "^3.9",
+                "phpspec/prophecy": "^1.22",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^11.5",
+                "rector/rector": "^1.2",
+                "sebastian/exporter": "^6.3.2",
+                "symfony/error-handler": "^6.1 || ^7.0 || ^8.0",
+                "symfony/var-dumper": "^6.1 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-xdebug": "For Xdebug profiling extension."
+            },
+            "bin": [
+                "bin/phpbench"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/Report/Func/functions.php"
+                ],
+                "psr-4": {
+                    "PhpBench\\": "lib/",
+                    "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "PHP Benchmarking Framework",
+            "keywords": [
+                "benchmarking",
+                "optimization",
+                "performance",
+                "profiling",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/phpbench/phpbench/issues",
+                "source": "https://github.com/phpbench/phpbench/tree/1.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dantleech",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-22T10:27:20+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -5130,6 +5434,70 @@
             "time": "2024-10-09T05:16:32+00:00"
         },
         {
+            "name": "seld/jsonlint",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-11T14:55:45+00:00"
+        },
+        {
             "name": "slevomat/coding-standard",
             "version": "8.22.1",
             "source": {
@@ -5633,6 +6001,145 @@
             "time": "2026-05-11T16:38:44+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.37.0",
             "source": {
@@ -6046,6 +6553,71 @@
                 }
             ],
             "time": "2026-04-10T18:47:49+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "d9593c9efa40499eb078b81144de42cbc28a31f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d9593c9efa40499eb078b81144de42cbc28a31f0",
+                "reference": "d9593c9efa40499eb078b81144de42cbc28a31f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:55:21+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6505,6 +7077,55 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
             "time": "2025-10-29T15:56:20+00:00"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/glob.git",
+                "reference": "8a2842112d6916e61e0e15e316465b611f3abc17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/glob/zipball/8a2842112d6916e61e0e15e316465b611f3abc17",
+                "reference": "8a2842112d6916e61e0e15e316465b611f3abc17",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "symfony/filesystem": "^5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozarts/glob/issues",
+                "source": "https://github.com/webmozarts/glob/tree/4.7.0"
+            },
+            "time": "2024-03-07T20:33:40+00:00"
         }
     ],
     "aliases": [],

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,7 @@
+{
+    "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
+    "runner.bootstrap":       "vendor/autoload.php",
+    "runner.file_pattern":    "*Bench.php",
+    "runner.path":            "benchmarks",
+    "runner.retry_threshold": 2
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.14.2@bbd217fc98c0daa0a13aea2a7f119d03ba3fc9a0">
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
   <file src="src/ConfigProvider.php">
     <DeprecatedClass>
       <code><![CDATA[Validator\PhoneNumber::class]]></code>
@@ -13,6 +13,11 @@
     <UnusedClass>
       <code><![CDATA[ExtensionNotLoadedException]]></code>
     </UnusedClass>
+  </file>
+  <file src="src/Exception/InvalidArgumentException.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[withUnknownCountryCode]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Filter/AbstractLocale.php">
     <DeprecatedClass>

--- a/src/CountryCode.php
+++ b/src/CountryCode.php
@@ -46,17 +46,34 @@ final readonly class CountryCode
      */
     public static function fromString(string $code): self
     {
-        $code = strtoupper($code);
-        if (! preg_match('/^[A-Z]{2}$/', $code)) {
+        $countryCode = self::validCountryCodeOrNull($code);
+        if ($countryCode === null) {
             throw InvalidArgumentException::withInvalidCountryCode($code);
+        }
+
+        return new self($countryCode);
+    }
+
+    /**
+     * @psalm-pure
+     * @return non-empty-string|null
+     */
+    private static function validCountryCodeOrNull(string $code): string|null
+    {
+        if ($code === '') {
+            return null;
+        }
+
+        if (! preg_match('/^[A-Z]{2}$/i', $code)) {
+            return null;
         }
 
         $displayName = Locale::getDisplayRegion('-' . $code, 'GB');
         if ($displayName === '' || $displayName === 'Unknown Region') {
-            throw InvalidArgumentException::withUnknownCountryCode($code);
+            return null;
         }
 
-        return new self($code);
+        return strtoupper($code);
     }
 
     /**
@@ -71,12 +88,30 @@ final readonly class CountryCode
      */
     public static function fromLocaleString(string $locale): self
     {
-        $region = Locale::getRegion($locale);
-        if ($region === null || $region === '') {
+        $region = self::countryCodeFromLocaleOrNull($locale);
+        if ($region === null) {
             throw InvalidArgumentException::withUnrecognizableLocaleString($locale);
         }
 
         return self::fromString($region);
+    }
+
+    /**
+     * @psalm-pure
+     * @return non-empty-string|null
+     */
+    private static function countryCodeFromLocaleOrNull(string $locale): string|null
+    {
+        if ($locale === '') {
+            return null;
+        }
+
+        $region = Locale::getRegion($locale);
+        if ($region === null || $region === '') {
+            return null;
+        }
+
+        return self::validCountryCodeOrNull($region);
     }
 
     /**
@@ -101,7 +136,7 @@ final readonly class CountryCode
         assert($countryCodeOrLocale !== '');
 
         $code = self::tryFromString($countryCodeOrLocale);
-        if ($code) {
+        if ($code instanceof self) {
             return $code;
         }
 
@@ -121,14 +156,14 @@ final readonly class CountryCode
      */
     public static function tryFromString(string $countryCodeOrLocale): ?self
     {
-        try {
-            return self::fromLocaleString($countryCodeOrLocale);
-        } catch (InvalidArgumentException) {
+        $country = self::validCountryCodeOrNull($countryCodeOrLocale);
+        if ($country !== null) {
+            return new self($country);
         }
 
-        try {
-            return self::fromString($countryCodeOrLocale);
-        } catch (InvalidArgumentException) {
+        $country = self::countryCodeFromLocaleOrNull($countryCodeOrLocale);
+        if ($country !== null) {
+            return new self($country);
         }
 
         return null;

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -16,7 +16,11 @@ class InvalidArgumentException extends \InvalidArgumentException implements Exce
         ));
     }
 
-    /** @psalm-pure */
+    /**
+     * @deprecated Since 2.33.0 This method is no longer used and will be removed in the next major version
+     *
+     * @psalm-pure
+     */
     public static function withUnknownCountryCode(string $code): self
     {
         return new self(sprintf(

--- a/test/CountryCodeTest.php
+++ b/test/CountryCodeTest.php
@@ -38,8 +38,8 @@ final class CountryCodeTest extends TestCase
     {
         self::assertTrue(
             CountryCode::fromString('GB')->equals(
-                CountryCode::fromString('gB')
-            )
+                CountryCode::fromString('gB'),
+            ),
         );
     }
 
@@ -47,22 +47,30 @@ final class CountryCodeTest extends TestCase
     {
         self::assertFalse(
             CountryCode::fromString('ZA')->equals(
-                CountryCode::fromString('US')
-            )
+                CountryCode::fromString('US'),
+            ),
         );
+    }
+
+    public function testEmptyStringForCountryCode(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Country codes should be 2 letter ISO 3166 strings, received ""');
+        /** @psalm-suppress InvalidArgument */
+        CountryCode::fromString('');
     }
 
     public function testPatternMatchFailureForCountryCode(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Country codes should be 2 letter ISO 3166 strings');
+        $this->expectExceptionMessage('Country codes should be 2 letter ISO 3166 strings, received "Wrong"');
         CountryCode::fromString('Wrong');
     }
 
     public function testInvalidCountryCode(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The country code "ZZ" does not correspond to a known country');
+        $this->expectExceptionMessage('Country codes should be 2 letter ISO 3166 strings, received "ZZ"');
         CountryCode::fromString('ZZ');
     }
 
@@ -126,7 +134,7 @@ final class CountryCodeTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The string "Wrong" could not be understood as either a locale or an ISO 3166 country code'
+            'The string "Wrong" could not be understood as either a locale or an ISO 3166 country code',
         );
         CountryCode::detect('Wrong');
     }
@@ -149,5 +157,50 @@ final class CountryCodeTest extends TestCase
         Locale::setDefault('en_GB');
         $code = CountryCode::detect('');
         self::assertEquals('GB', $code->toString());
+    }
+
+    /** @return list<array{0: string}> */
+    public static function invalidArbitraryStrings(): array
+    {
+        return [
+            ['zz'],
+            ['ZZ'],
+            [''],
+            ['wrong'],
+            ['bad-news'],
+            ['zz_ZZ'],
+        ];
+    }
+
+    #[DataProvider('invalidArbitraryStrings')]
+    public function testTryFromStringWithInvalidInput(string $input): void
+    {
+        /** @psalm-suppress ArgumentTypeCoercion */
+        self::assertNull(CountryCode::tryFromString($input));
+    }
+
+    /** @return list<array{0: non-empty-string, 1: non-empty-string}> */
+    public static function validArbitraryStrings(): array
+    {
+        return [
+            ['gb', 'GB'],
+            ['UA', 'UA'],
+            ['de_DE', 'DE'],
+            ['ZA', 'ZA'],
+            ['sl-Latn-IT-nedis', 'IT'],
+            ['FR-fr@EURO', 'FR'],
+        ];
+    }
+
+    /**
+     * @param non-empty-string $input
+     * @param non-empty-string $expect
+     */
+    #[DataProvider('validArbitraryStrings')]
+    public function testTryFromStringWithValidInput(string $input, string $expect): void
+    {
+        $countryCode = CountryCode::tryFromString($input);
+        self::assertNotNull($countryCode);
+        self::assertSame($expect, $countryCode->toString());
     }
 }


### PR DESCRIPTION
<details open>
<summary>Before</summary>

```
+-------------------------------+-------------------------------------+-----+------+-----+----------+----------+--------+
| benchmark                     | subject                             | set | revs | its | mem_peak | mode     | rstdev |
+-------------------------------+-------------------------------------+-----+------+-----+----------+----------+--------+
| CountryCodeTryFromStringBench | benchInvalidArgumentToTryFromString |     | 100  | 20  | 4.605mb  | 10.155μs | ±0.98% |
| CountryCodeTryFromStringBench | benchValidInputFromString           |     | 100  | 20  | 4.605mb  | 9.902μs  | ±0.85% |
+-------------------------------+-------------------------------------+-----+------+-----+----------+----------+--------+
```

</summary>

<details open>
<summary>After</summary>

```
+-------------------------------+-------------------------------------+-----+------+-----+---------------+-----------------+---------------+
| benchmark                     | subject                             | set | revs | its | mem_peak      | mode            | rstdev        |
+-------------------------------+-------------------------------------+-----+------+-----+---------------+-----------------+---------------+
| CountryCodeTryFromStringBench | benchInvalidArgumentToTryFromString |     | 100  | 20  | 4.605mb 0.00% | 4.599μs -54.71% | ±0.95% -2.99% |
| CountryCodeTryFromStringBench | benchValidInputFromString           |     | 100  | 20  | 4.605mb 0.00% | 7.965μs -19.56% | ±0.84% -1.21% |
+-------------------------------+-------------------------------------+-----+------+-----+---------------+-----------------+---------------+
```

</summary>
