### PR TITLE
Fix: Plural translations were not correctly loaded by the ini file loader.

### DIFF
--- a/src/Translator/Loader/Ini.php
+++ b/src/Translator/Loader/Ini.php
@@ -8,6 +8,7 @@ use Laminas\I18n\Exception\InvalidArgumentException;
 use Laminas\I18n\Translator\Plural\Rule as PluralRule;
 use Laminas\I18n\Translator\TextDomain;
 
+use function array_is_list;
 use function array_shift;
 use function count;
 use function is_array;
@@ -67,7 +68,10 @@ final readonly class Ini implements FileLoaderInterface
             /** @psalm-var mixed $value */
             $value = array_shift($message);
 
-            if (is_string($key) && is_string($value)) {
+            $validValue = is_string($value)
+                || (is_array($value) && self::isStringList($value));
+
+            if (is_string($key) && $validValue) {
                 $messages[$key] = $value;
             }
         }
@@ -84,5 +88,24 @@ final readonly class Ini implements FileLoaderInterface
         }
 
         return $textDomain;
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     * @psalm-assert-if-true list<string> $value
+     */
+    private static function isStringList(array $value): bool
+    {
+        if (! array_is_list($value)) {
+            return false;
+        }
+
+        foreach ($value as $item) {
+            if (! is_string($item)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/test/Translator/Loader/IniTest.php
+++ b/test/Translator/Loader/IniTest.php
@@ -86,6 +86,20 @@ final class IniTest extends TestCase
         self::assertEquals('Message 4 (en)', $textDomain['Message 4']);
     }
 
+    public function testLoaderReturnsAnArrayOfEntriesForPlurals(): void
+    {
+        $loader     = new IniLoader(new IniFileReader());
+        $textDomain = $loader->load('en_EN', $this->testFilesDir . '/translation_en.ini');
+        self::assertInstanceOf(TextDomain::class, $textDomain);
+
+        $expect = [
+            0 => 'Message 5 (en) Plural 0',
+            1 => 'Message 5 (en) Plural 1',
+            2 => 'Message 5 (en) Plural 2',
+        ];
+        self::assertSame($expect, $textDomain['Message 5']);
+    }
+
     public function testLoaderLoadsPluralRules(): void
     {
         $loader     = new IniLoader(new IniFileReader());

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -8,6 +8,7 @@ use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\EventManager;
 use Laminas\I18n\I18nDefaults;
+use Laminas\I18n\Translator\Loader\Ini;
 use Laminas\I18n\Translator\Loader\PhpArray;
 use Laminas\I18n\Translator\TextDomain;
 use Laminas\I18n\Translator\TranslationCollector\TranslationCollectorInterface;
@@ -162,6 +163,32 @@ final class TranslatorTest extends TestCase
                         [
                             'type'     => PhpArray::class,
                             'filename' => $this->testFilesDir . '/translation_en.php',
+                            'locale'   => 'en_US',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $pl0 = $translator->translatePlural('Message 5', 'Message 5 Plural', 1);
+        $pl1 = $translator->translatePlural('Message 5', 'Message 5 Plural', 2);
+        $pl2 = $translator->translatePlural('Message 5', 'Message 5 Plural', 10);
+
+        self::assertEquals('Message 5 (en) Plural 0', $pl0);
+        self::assertEquals('Message 5 (en) Plural 1', $pl1);
+        self::assertEquals('Message 5 (en) Plural 2', $pl2);
+    }
+
+    public function testTranslatePluralsUsingIniFileFormat(): void
+    {
+        $translator = $this->translatorWithConfig([
+            'locale'       => 'en_US',
+            'laminas-i18n' => [
+                'translator' => [
+                    'translation_files' => [
+                        [
+                            'type'     => Ini::class,
+                            'filename' => $this->testFilesDir . '/translation_en.ini',
                             'locale'   => 'en_US',
                         ],
                     ],

--- a/test/Translator/TranslatorTest/translation_en.ini
+++ b/test/Translator/TranslatorTest/translation_en.ini
@@ -1,0 +1,26 @@
+[plural]
+plural_forms = 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);'
+
+[translation]
+identifier1.message  = "Message 1"
+identifier1.translation  = "Message 1 (en)"
+
+identifier2.message  = "Message 2"
+identifier2.translation  = "Message 2 (en)"
+
+identifier3.message  = "Message 3"
+identifier3.translation  = "Message 3 (en)"
+
+identifier4.message  = "Message 4"
+identifier4.translation  = "Message 4 (en)"
+
+identifier5.message  = "Message 5"
+identifier5.translation.0  = "Message 5 (en) Plural 0"
+identifier5.translation.1  = "Message 5 (en) Plural 1"
+identifier5.translation.2  = "Message 5 (en) Plural 2"
+
+identifier6.message  = "Cooking furniture"
+identifier6.translation  = "Küchen Möbel (en)"
+
+identifier7.message  = "Küchen Möbel"
+identifier7.translation  = "Cooking furniture (en)"


### PR DESCRIPTION
The ini loader was silently rejecting lists of translation values, meaning that plural translations would not be loaded or used when using ini file format