### PR TITLE
docs: update v3 documentation

### DIFF
--- a/docs/book/v3/application-integration/stand-alone.md
+++ b/docs/book/v3/application-integration/stand-alone.md
@@ -19,14 +19,29 @@ return [
 Create the translator instance and add the translation file.
 
 ```php
-$translator = new Laminas\I18n\Translator\Translator();
-$translator->addTranslationFile(
-    Laminas\I18n\Translator\Loader\PhpArray::class,
-    __DIR__ . '/languages/de_DE.php',
-    'default',
-    'de_DE'
+$container = (new Laminas\ServiceManager\ServiceManager(
+    (new Laminas\I18n\ConfigProvider())->getDependencyConfig()
+));
+
+$container->setService(
+    'config',
+    [
+        'laminas-i18n' => [
+            'translator' => [
+                'translation_files' => [
+                    [
+                        'type'     => Laminas\I18n\Translator\Loader\PhpArray::class,
+                        'filename' => __DIR__ . '/languages/de_DE.php',
+                        'locale'   => 'de_DE',
+                    ],
+                ],
+            ],
+        ],
+    ]
 );
-```
+
+$translator = $container->get(Laminas\Translator\TranslatorInterface::class);
+ ```
 
 ### Translate Messages
 

--- a/docs/book/v3/filters/introduction.md
+++ b/docs/book/v3/filters/introduction.md
@@ -1,22 +1,21 @@
 # Introduction
 
-laminas-i18n ships with a set of internationalization-related filters.
+The `laminas-i18n` ecosystem provides a set of internationalization-related filters to sanitize and normalize localized data:
 
 - [Alnum](alnum.md)
 - [Alpha](alpha.md)
 - [NumberFormat](number-format.md)
 - [NumberParse](number-parse.md)
 
-These filters are based on Laminas component for filtering and
-normalizing data and files:
-[laminas-filter](https://docs.laminas.dev/laminas-filter/).
+These filters are designed to work seamlessly with the [laminas-filter](https://docs.laminas.dev/laminas-filter/) component pipeline. For general concepts, workflows, and basic usage instructions regarding filters, please refer to the [laminas-filter documentation](https://docs.laminas.dev/laminas-filter/).
 
-The concept and the basic usage of the filters can be found in the
-[documentation of laminas-filter](https://docs.laminas.dev/laminas-filter/).
+## Installation
 
-> MISSING: **Installation Requirements**
-> The filtering support of laminas-i18n depends on the [laminas-filter](https://docs.laminas.dev/laminas-filter/) component, so be sure to have it installed before getting started:
->
-> ```bash
-> $ composer require laminas/laminas-filter
-> ```
+Starting with version 3.0, the core `laminas-i18n` package no longer ships with these filters out of the box. They have been extracted into an optional satellite package.
+
+To use internationalization filters in your application, you must explicitly install the `laminas-i18n-filter` package, which will automatically bring in `laminas-filter` as a required dependency:
+
+```bash
+$ composer require laminas/laminas-i18n-filter
+
+```

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -42,6 +42,54 @@ $loader = new IniLoader(new IniFileReader());
 
 ```
 
+### Config Namespace Consolidation
+
+To prevent configuration key pollution in global configurations, all translator top-level options must now be nested under the `laminas-i18n` configuration key.
+
+#### Prior to 3.0.0
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'translator' => [
+        'translation_file_patterns' => [
+            [
+                'type'     => 'phparray',
+                'base_dir' => dirname(__DIR__, 2) . '/data/languages',
+                'pattern'  => '%s.php',
+            ],
+        ],
+    ],
+];
+
+```
+
+#### Since 3.0.0
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'laminas-i18n' => [
+        'translator' => [
+            'translation_file_patterns' => [
+                [
+                    'type'     => 'phparray',
+                    'base_dir' => dirname(__DIR__, 2) . '/data/languages',
+                    'pattern'  => '%s.php',
+                ],
+            ],
+        ],
+    ],
+];
+
+```
+
 ## Behaviour Changes
 
 The deprecated, static constructor `Laminas\I18n\Exception\InvalidArgumentException::withUnknownCountryCode()` has been removed.

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -114,6 +114,28 @@ Additionally, these filters have been reworked to ensure native compatibility wi
 > $ composer require laminas/laminas-i18n-filter
 > ```
 
+### Extraction of I18n Validators to Satellite Package
+
+The component's built-in validation capabilities have been extracted into an external standalone package: [`laminas/laminas-i18n-validator`](https://github.com/laminas/laminas-i18n-validator).
+
+The following validator classes are no longer present directly within `laminas-i18n`:
+- `Laminas\I18n\Validator\Alnum`
+- `Laminas\I18n\Validator\Alpha`
+- `Laminas\I18n\Validator\CountryCode`
+- `Laminas\I18n\Validator\DateTime`
+- `Laminas\I18n\Validator\IsFloat`
+- `Laminas\I18n\Validator\IsInt`
+- `Laminas\I18n\Validator\PhoneNumber` (Note: Historical wrapper configuration only; see above for full structural replacement details)
+- `Laminas\I18n\Validator\PostCode`
+
+Additionally, these extracted validators have been internally refactored to achieve seamless native compatibility with the `laminas-validator` v3 engine and plugin management layers.
+
+> [!IMPORTANT] Migration Action Required
+> If your validation chains or forms rely on any of these i18n validation plugins, you must explicitly require the new satellite package via Composer:
+> ```bash
+> $ composer require laminas/laminas-i18n-validator
+> ```
+
 ### `Laminas\I18n\Translator\Loader\Ini` Initialization
 
 Due to the removal of `laminas-config`, the `Ini` translator loader no longer implicitly instantiates an internal configuration reader. It now requires `Laminas\I18n\Translator\Loader\IniFileReader` passed explicitly to its constructor.

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -25,7 +25,7 @@ The MVC `Module` class has been entirely removed from the package.
 
 ### Interface Namespace Extraction / Consolidation
 
-To better split component responsibilities and streamline the core architecture, core interfaces have been extracted or moved to separate, dedicated packages. 
+To better split component responsibilities and streamline the core architecture, core interfaces have been extracted or moved to separate, dedicated packages.
 
 Usages of `Laminas\I18n\Translator\TranslatorInterface` must be replaced with `Laminas\Translator\TranslatorInterface`.
 
@@ -101,24 +101,27 @@ return [
 The component's built-in filtering capabilities have been extracted into an external standalone package: [`laminas/laminas-i18n-filter`](https://github.com/laminas/laminas-i18n-filter).
 
 The following filter classes are no longer present in `laminas-i18n`:
-* `Laminas\I18n\Filter\Alnum`
-* `Laminas\I18n\Filter\Alpha`
-* `Laminas\I18n\Filter\NumberFormat`
-* `Laminas\I18n\Filter\NumberParse`
+
+- `Laminas\I18n\Filter\Alnum`
+- `Laminas\I18n\Filter\Alpha`
+- `Laminas\I18n\Filter\NumberFormat`
+- `Laminas\I18n\Filter\NumberParse`
 
 Additionally, these filters have been reworked to ensure native compatibility with `laminas-filter` v3 execution pipelines.
 
 > [!IMPORTANT] Migration Action Required
 > If your application relies on these filters, you must explicitly require the new satellite package:
-> ```bash
-> $ composer require laminas/laminas-i18n-filter
-> ```
+
+```bash
+$ composer require laminas/laminas-i18n-filter
+```
 
 ### Extraction of I18n Validators to Satellite Package
 
 The component's built-in validation capabilities have been extracted into an external standalone package: [`laminas/laminas-i18n-validator`](https://github.com/laminas/laminas-i18n-validator).
 
 The following validator classes are no longer present directly within `laminas-i18n`:
+
 - `Laminas\I18n\Validator\Alnum`
 - `Laminas\I18n\Validator\Alpha`
 - `Laminas\I18n\Validator\CountryCode`
@@ -132,9 +135,10 @@ Additionally, these extracted validators have been internally refactored to achi
 
 > [!IMPORTANT] Migration Action Required
 > If your validation chains or forms rely on any of these i18n validation plugins, you must explicitly require the new satellite package via Composer:
-> ```bash
-> $ composer require laminas/laminas-i18n-validator
-> ```
+
+```bash
+$ composer require laminas/laminas-i18n-validator
+```
 
 ### `Laminas\I18n\Translator\Loader\Ini` Initialization
 

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -1,12 +1,46 @@
 # Migration from Versions 2.x to 3.0
 
+## Removed Dependencies
+
+### `laminas/laminas-config`
+
+The dependency on `laminas/laminas-config` has been removed. The component now utilizes a built-in INI file reader implementation instead.
+
 ## Removed Classes
 
 ### `Laminas\I18n\Validator\PhoneNumber`
 
 The deprecated phone number validator has been removed in favour of the standalone library [`laminas-i18n-phone-number`](https://github.com/laminas/laminas-i18n-phone-number).
 
-In most cases, the phone number library can be used as a direct replacement by using `Laminas\I18n\PhoneNumber\Validator\PhoneNumber`
+In most cases, the phone number library can be used as a direct replacement by using `Laminas\I18n\PhoneNumber\Validator\PhoneNumber`.
+
+## Backward-Incompatible Changes
+
+### `Laminas\I18n\Translator\Loader\Ini` Initialization
+
+Due to the removal of `laminas-config`, the `Ini` translator loader no longer implicitly instantiates an internal configuration reader. It now requires `Laminas\I18n\Translator\Loader\IniFileReader` passed explicitly to its constructor.
+
+> [!NOTE] Service Container Notice
+> If your application resolves the `Ini` translation loader via a service container (such as `Laminas\ServiceManager`), this instantiation change is automatically handled by the component's internal factories. Manual intervention is only required if you instantiate the loader directly in your code.
+
+#### Prior to 3.0.0
+
+```php
+use Laminas\I18n\Translator\Loader\Ini as IniLoader;
+
+$loader = new IniLoader();
+
+```
+
+#### Since 3.0.0
+
+```php
+use Laminas\I18n\Translator\Loader\Ini as IniLoader;
+use Laminas\I18n\Translator\Loader\IniFileReader;
+
+$loader = new IniLoader(new IniFileReader());
+
+```
 
 ## Behaviour Changes
 

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -29,6 +29,73 @@ To better split component responsibilities and streamline the core architecture,
 
 Usages of `Laminas\I18n\Translator\TranslatorInterface` must be replaced with `Laminas\Translator\TranslatorInterface`.
 
+### Migration to Container-Driven Caching via Translation Collectors
+
+The `Translator` component no longer manages caching internally, and the legacy `$translator->setCache()` method has been entirely removed. Caching is now decoupled from the translator itself and is handled architectural-level by wrapping translation lookup routines inside specific Translation Collectors.
+
+When the `AggregateCollector` is resolved from the dependency injection container, an internal delegator factory checks the application configuration for a defined PSR-6 or PSR-16 cache service. If a valid cache service name is found and successfully retrieved from the container, the factory automatically wraps the `AggregateCollector` in a `CachingCollector`. This decorator transparently proxies all lookup tasks via `TranslationCollectorInterface::collect()` and caches the results.
+
+#### Configuration Changes
+
+To enable translation caching, the caching service must be registered within the dependency container and point to its service name under the consolidated `laminas-i18n` configuration block. Either a standard PSR-6 (`psr6_cache`) or a PSR-16 (`psr16_cache`) storage implementation can be provided.
+
+An optional `cache_key_prefix` can also be supplied to prevent key collisions in shared cache environments.
+
+> [!CAUTION] Type Errors on Direct Injections
+> Manual invocation of caching configurations on the translator object or attempting to pass raw legacy `laminas-cache` adapter instances via configuration arrays will result in a `TypeError`. All caching must be registered as container services.
+
+#### Prior to 3.0.0
+
+```php
+use Laminas\Cache\StorageFactory;
+use Laminas\I18n\Translator\Translator;
+
+$cache = StorageFactory::factory([
+    'adapter' => 'filesystem',
+]);
+
+$translator = new Translator();
+$translator->setCache($cache);
+
+```
+
+#### Since 3.0.0
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'dependencies' => [
+        'factories' => [
+            // Register the PSR-6 or PSR-16 compliant cache service factory
+            'MyApp\CacheService' => MyApp\Cache\CacheFactory::class,
+        ],
+    ],
+    'laminas-i18n' => [
+        'translator' => [
+            // Point to the service container key
+            'psr6_cache'       => 'MyApp\CacheService', 
+            // Alternatively, use a PSR-16 cache provider:
+            // 'psr16_cache'    => 'MyApp\SimpleCacheService',
+            
+            // Optional: Customize the translation cache isolation
+            'cache_key_prefix' => 'app_translation_',
+            
+            'translation_file_patterns' => [
+                [
+                    'type'     => 'phparray',
+                    'base_dir' => dirname(__DIR__, 2) . '/data/languages',
+                    'pattern'  => '%s.php',
+                ],
+            ],
+        ],
+    ],
+];
+
+```
+
 ### `Laminas\I18n\Translator\Loader\Ini` Initialization
 
 Due to the removal of `laminas-config`, the `Ini` translator loader no longer implicitly instantiates an internal configuration reader. It now requires `Laminas\I18n\Translator\Loader\IniFileReader` passed explicitly to its constructor.

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -16,6 +16,13 @@ In most cases, the phone number library can be used as a direct replacement by u
 
 ## Backward-Incompatible Changes
 
+### Drop MVC Support (`Laminas\I18n\Module` Removal)
+
+The MVC `Module` class has been entirely removed from the package.
+
+> [!CAUTION] No Migration Path for MVC Applications
+> Integration with `laminas-mvc` is completely dropped. There is no official upgrade path for legacy MVC applications because `laminas-mvc` will not be updated to support ServiceManager v4. Consequently, version 3.0+ of this component cannot be installed alongside the core MVC framework stack.
+
 ### Interface Namespace Extraction / Consolidation
 
 To better split component responsibilities and streamline the core architecture, core interfaces have been extracted or moved to separate, dedicated packages. 

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -96,6 +96,24 @@ return [
 
 ```
 
+### Extraction of I18n Filters to Satellite Package
+
+The component's built-in filtering capabilities have been extracted into an external standalone package: [`laminas/laminas-i18n-filter`](https://github.com/laminas/laminas-i18n-filter).
+
+The following filter classes are no longer present in `laminas-i18n`:
+* `Laminas\I18n\Filter\Alnum`
+* `Laminas\I18n\Filter\Alpha`
+* `Laminas\I18n\Filter\NumberFormat`
+* `Laminas\I18n\Filter\NumberParse`
+
+Additionally, these filters have been reworked to ensure native compatibility with `laminas-filter` v3 execution pipelines.
+
+> [!IMPORTANT] Migration Action Required
+> If your application relies on these filters, you must explicitly require the new satellite package:
+> ```bash
+> $ composer require laminas/laminas-i18n-filter
+> ```
+
 ### `Laminas\I18n\Translator\Loader\Ini` Initialization
 
 Due to the removal of `laminas-config`, the `Ini` translator loader no longer implicitly instantiates an internal configuration reader. It now requires `Laminas\I18n\Translator\Loader\IniFileReader` passed explicitly to its constructor.

--- a/docs/book/v3/migration/migration-from-2-to-3.md
+++ b/docs/book/v3/migration/migration-from-2-to-3.md
@@ -16,6 +16,12 @@ In most cases, the phone number library can be used as a direct replacement by u
 
 ## Backward-Incompatible Changes
 
+### Interface Namespace Extraction / Consolidation
+
+To better split component responsibilities and streamline the core architecture, core interfaces have been extracted or moved to separate, dedicated packages. 
+
+Usages of `Laminas\I18n\Translator\TranslatorInterface` must be replaced with `Laminas\Translator\TranslatorInterface`.
+
 ### `Laminas\I18n\Translator\Loader\Ini` Initialization
 
 Due to the removal of `laminas-config`, the `Ini` translator loader no longer implicitly instantiates an internal configuration reader. It now requires `Laminas\I18n\Translator\Loader\IniFileReader` passed explicitly to its constructor.

--- a/docs/book/v3/translation.md
+++ b/docs/book/v3/translation.md
@@ -1,65 +1,131 @@
 # Translation
 
-laminas-i18n comes with a complete translation suite supporting all major formats
-and including popular features such as plural translations and text domains. The
-Translator subcomponent is mostly dependency free, except for the fallback to a
-default locale, where it relies on the PHP's intl extension.
+`laminas-i18n` comes with a complete translation suite supporting all major
+formats and including popular features such as plural translations and text
+domains.
 
-The translator itself is initialized without any parameters, as any
-configuration to it is optional. A translator without any translations will do
-nothing but return all messages verbatim.
+The component is entirely configuration-driven and designed to work seamlessly
+within a dependency injection environment. Instead of manual instantiation,
+instances should be fetched directly from a PSR-11 compatible service container
+(such as `laminas-servicemanager`).
 
-## Adding translations
+## Adding Translations
 
-Two options exist for adding translations to the translator:
+Translations are integrated into the translator via your application configuration files (e.g., `config/autoload/i18n.global.php`).
 
-- Add every translation file individually; use this for translation formats that
-  store multiple locales in the same file.
-- Add translation files based on a pattern; use this for formats that use one
-  file per locale.
+The translator is driven by an underlying `AggregateCollector` (which may be transparently wrapped in a `CachingCollector` if a cache service is configured). This aggregate collector orchestrates multiple specialized sub-collectors simultaneously:
 
-To add a single file to the translator, use the `addTranslationFile()` method:
+- `FileListCollector`: Inspects explicitly declared individual files.
+- `FilePatternCollector`: Scans directories using global matching layout patterns.
+- `RemoteListCollector`: Coordinates lookups from remote databases or API endpoints (available if custom remote loaders are registered).
 
-```php
-use Laminas\I18n\Translator\Translator;
+When a translation lookup occurs, all active collectors are consulted in parallel, and their translation assets are merged into a unified dataset. You can configure any combination of these strategies concurrently within your `laminas-i18n` configuration block.
 
-$translator = new Translator();
-$translator->addTranslationFile($type, $filename, $textDomain, $locale);
-```
+### Configuration via Explicit Files (FileListCollector)
 
-where the arguments are:
-
-- `$type`: the name of the format loader to use; see the next section for
-  details.
-- `$filename`: the file containing translations.
-- `$textDomain`: a "category" name for translations. If this is omitted, it
-  defaults to "default". Use text domains to segregate translations by context.
-- `$locale`: the language strings are translated from; this argument is only
-  required for formats which contain translations for single locales.
-
-When storing one locale per file, you should specify those files via a pattern.
-This allows you to add new translations to the file system, without touching
-your code. Patterns are added with the `addTranslationFilePattern()` method:
+To map single file targets manually file-by-file, utilize the `translation_files` configuration key. This is ideal for one-off locales, complex directory structures that layout patterns cannot easily scan, or assets isolated to specific text domains.
 
 ```php
-use Laminas\I18n\Translator\Translator;
+<?php
 
-$translator = new Translator();
-$translator->addTranslationFilePattern($type, $baseDir, $pattern, $textDomain);
+declare(strict_types=1);
+
+return [
+    'laminas-i18n' => [
+        'translator' => [
+            'translation_files' => [
+                [
+                    'type'        => 'phparray',
+                    'filename'    => dirname(__DIR__, 2) . '/data/languages/en_US.php',
+                    'locale'      => 'en_US',
+                ],
+            ],
+        ],
+    ],
+];
+
 ```
 
-where the arguments are roughly the same as for `addTranslationFile()`, with a
-few differences:
+- `type`: The identifier of the format loader to use (e.g., `phparray`, `gettext`, `ini`).
+- `filename`: The absolute path to the file containing your translation keys.
+- `locale`: The language locale target this file fulfills. This is required for flat formats hosting single-locale keys.
+- `text_domain`: An optional "category" name to isolate translations by context. If omitted, it defaults to `"default"`.
 
-- `$baseDir` is a directory containing translation files.
-- `$pattern` is an `sprintf()`-formatted string describing a pattern for
-  locating files under `$baseDir`. The `$pattern` should contain a substitution
-  character for the `$locale` &mdash; which is omitted from the
-  `addTranslationFilePattern()` call, but passed whenever a translation is
-  requested. Use either `%s` or `%1$s` in the `$pattern` as a placeholder for
-  the locale. As an example, if your translation files are located in
-  `/var/messages/<LOCALE>/messages.mo`, your pattern would be
-  `/var/messages/%s/messages.mo`.
+### Configuration via File Patterns (FilePatternCollector)
+
+When managing a modular dictionary structure where each locale owns its own distinct file, use the `translation_file_patterns` array. This enables your application to scale cleanly; dropping a new locale file into the target directory automatically makes it available without modifying any code or configuration arrays.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'laminas-i18n' => [
+        'translator' => [
+            'translation_file_patterns' => [
+                [
+                    'type'        => 'phparray',
+                    'base_dir'    => dirname(__DIR__, 2) . '/data/languages',
+                    'pattern'     => '%s.php',
+                ],
+            ],
+        ],
+    ],
+];
+
+```
+
+- `base_dir`: The root directory containing your structured translation file tree.
+- `pattern`: An `sprintf()`-compliant formatting string outlining how to locate files under the `base_dir`. It must include a string substitution placeholder (`%s` or `%1$s`) which represents the active `locale` being requested. For example, if your translation files reside at `/var/messages/{locale}/messages.mo`, your pattern string must be `/var/messages/%s/messages.mo`.
+- `text_domain`: An optional contextual category name. Defaults to `"default"`.
+
+### Configuration via Remote Assets (RemoteListCollector)
+
+If you serve translation values dynamically from a database table, a Redis instance, or an external translation API, you can supply a `remote_translation` array.
+
+> [!NOTE] Custom Implementations Required
+> The `RemoteListCollector` is configured and ready to execute out-of-the-box, but the core component does not bundle default, concrete remote loaders. You must implement `Laminas\I18n\Translator\Loader\RemoteLoaderInterface` and register your custom service key.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'laminas-i18n' => [
+        'translator' => [
+            'remote_translation' => [
+                [
+                    'type'        => 'MyCustomDatabaseLoader',
+                ],
+            ],
+        ],
+    ],
+];
+
+```
+
+- `type`: The identifier or class name of the custom remote format loader registered within the `MessageLoaderPluginManagerInterface`. It must resolve to a non-empty string.
+- `text_domain`: A contextual category name used to isolate or segment these remote translations. If this is omitted, it automatically falls back to your application's configured default text domain (via `I18nDefaults`). It must resolve to a non-empty string.
+
+## Container Retrieval
+
+To obtain the fully initialized and configured `Translator` instance, retrieve
+it directly from your DI container:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Laminas\I18n\Translator\Translator;
+use Psr\Container\ContainerInterface;
+
+/** @var ContainerInterface $container */
+$translator = $container->get(Translator::class);
+
+```
 
 ## Supported formats
 

--- a/docs/book/v3/validators/introduction.md
+++ b/docs/book/v3/validators/introduction.md
@@ -1,7 +1,6 @@
 # Introduction
 
-laminas-i18n provides a set of validators that use internationalization
-capabilities.
+The `laminas-i18n` ecosystem provides a robust set of validators that leverage internationalization capabilities to sanitize and validate localized input data:
 
 - [Alnum](alnum.md)
 - [Alpha](alpha.md)
@@ -12,14 +11,18 @@ capabilities.
 - [PhoneNumber](phone-number.md)
 - [PostCode](post-code.md)
 
-These validators are based on Laminas component for validation of data
-and files: [laminas-validator](https://docs.laminas.dev/laminas-validator/).
-The documentation of laminas-validator also describes the
-[translate of the validation messages](https://docs.laminas.dev/laminas-validator/intro/#translating-messages).
+These validators extend and integrate with the core validation component
+pipeline: [laminas-validator](https://docs.laminas.dev/laminas-validator/). For
+information on standard validation workflows or error message localization,
+please consult the [laminas-validator documentation](https://docs.laminas.dev/laminas-validator/intro/#translating-messages).
 
-> MISSING: **Installation Requirements**
-> The validation support of laminas-i18n depends on the [laminas-validator](https://docs.laminas.dev/laminas-validator/) component, so be sure to have it installed before getting started:
->
-> ```bash
-> $ composer require laminas/laminas-validator
-> ```
+## Installation Requirements
+
+Starting with version 3.0, the core `laminas-i18n` package no longer ships with these validators built-in. They have been extracted into an optional satellite package to keep core component dependencies lightweight.
+
+To use internationalization validators in your application, you must explicitly require the standalone package:
+
+```bash
+$ composer require laminas/laminas-i18n-validator
+
+```


### PR DESCRIPTION
|    Q          | A    |
|-------------- |------|
| Documentation | yes  |
| Bugfix        | no   |
| BC Break      | no   |
| New Feature   | no   |
| RFC           | no   |
| QA            | no   |

### Description

This PR updates and rewrites the migration guide and component documentation for the upcoming `3.0.0` release. It addresses multiple documentation requirements tracking breaking architectural changes and component deprecations.

#### Associated Issues:

- #168
- #169
- #172
- #174
- #177
- #178